### PR TITLE
rescan-scsi-bus.sh: Add lunsearch filter to searchexisting()

### DIFF
--- a/scripts/rescan-scsi-bus.sh
+++ b/scripts/rescan-scsi-bus.sh
@@ -4,7 +4,7 @@
 # (c) 2006--2015 Hannes Reinecke, GNU GPL v2 or later
 # $Id: rescan-scsi-bus.sh,v 1.57 2012/03/31 14:08:48 garloff Exp $
 
-VERSION="20160511"
+VERSION="20160831"
 SCAN_WILD_CARD=4294967295
 
 setcolor ()
@@ -715,7 +715,16 @@ searchexisting()
     else
       match=1
     fi
-    test $match -eq 1 && doreportlun
+
+    test $match -eq 0 && continue
+
+    if [ -z "$lunsearch" ] ; then
+      doreportlun
+    else
+      for lun in $lunsearch ; do
+        dolunscan
+      done
+    fi
   done
 }
 


### PR DESCRIPTION
    A user has reported that `rescan-scsi-bus.sh --luns=<lun #>` prints
    all existing LUNs and scans all new LUNs instead of only the ones
    specified. The problem is that searchexisting() always calls
    doreportlun() and is missing the lunsearch filter e.g. used in
    dosearch().
    So add the required lunsearch filter from dosearch() to
    searchexisting().