### PR TITLE
sg3_utils: Fix rescan-scsi-bus.sh to readd when using --forceremove

### DIFF
--- a/scripts/rescan-scsi-bus.sh
+++ b/scripts/rescan-scsi-bus.sh
@@ -499,6 +499,7 @@ dolunscan()
         fi
         echo 1 > /sys/class/scsi_device/${host}:${channel}:${id}:${lun}/device/delete
         sleep 0.02
+        echo "scsi add-single-device $devnr" > /proc/scsi/scsi
       else
         echo "scsi remove-single-device $devnr" > /proc/scsi/scsi
         if test $RC -eq 1 -o $lun -eq 0 ; then


### PR DESCRIPTION
When using rescan-scsi-bus.sh with the --forceremove option, expectation,
taken from the --help of the command, is to "Remove and readd every device".
Currently, the devices are removed, but we do not readd.
Added additional line to ensure readd attempt.
