### PR TITLE
rescan-scsi-bus.sh: Fix manpage of --forcerescan

### DIFF
--- a/doc/rescan-scsi-bus.sh.8
+++ b/doc/rescan-scsi-bus.sh.8
@@ -35,10 +35,10 @@ enable debug                       [default: 0]
 flush failed multipath devices     [default: disabled]
 .TP
 \fB\-\-forceremove\fR
-remove and readd every device (DANGEROUS)
+remove stale devices (DANGEROUS)
 .TP
 \fB\-\-forcerescan\fR
-rescan existing devices
+remove and readd existing devices (DANGEROUS)
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 print usage message then exit


### PR DESCRIPTION
Just align the manpage with command help text.

~~Patch 1/2 is the one found in sles12-sp2 branch.~~