### PR TITLE
rescan-scsi-bus.sh: use LUN wildcard in idlist

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@ Each utility has its own version number, date of last change and
 some description at the top of its ".c" file. All utilities in the main
 directory have their own "man" pages. There is also a sg3_utils man page.
 
-Changelog for sg3_utils-1.43 [20180712] [svn: r782]
+Changelog for sg3_utils-1.43 [20180715] [svn: r783]
   - sg_write_x: where x can be normal, atomic, or(write),
     same, scattered, or stream writes with 16 or 32 byte
     cdbs (sbc4r04 for atomic, sbc4r11 for scattered)

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@ Each utility has its own version number, date of last change and
 some description at the top of its ".c" file. All utilities in the main
 directory have their own "man" pages. There is also a sg3_utils man page.
 
-Changelog for sg3_utils-1.43 [20180715] [svn: r783]
+Changelog for sg3_utils-1.43 [20180716] [svn: r784]
   - sg_write_x: where x can be normal, atomic, or(write),
     same, scattered, or stream writes with 16 or 32 byte
     cdbs (sbc4r04 for atomic, sbc4r11 for scattered)
@@ -19,6 +19,7 @@ Changelog for sg3_utils-1.43 [20180715] [svn: r783]
       > 4 TB and 80 hours if > 8 TB
   - sg_decode sense: add --cdb and --err=ES options
   - sg_ses: handle 2 bit EIIOE field in aes dpage
+    - increase join array size from 260 to 520 elements 
     - add --quiet option to suppress messages
     - expand join handling of SAS connectors and others
     - expand join debug code

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@ Each utility has its own version number, date of last change and
 some description at the top of its ".c" file. All utilities in the main
 directory have their own "man" pages. There is also a sg3_utils man page.
 
-Changelog for sg3_utils-1.43 [20180716] [svn: r784]
+Changelog for sg3_utils-1.43 [20180724] [svn: r785]
   - sg_write_x: where x can be normal, atomic, or(write),
     same, scattered, or stream writes with 16 or 32 byte
     cdbs (sbc4r04 for atomic, sbc4r11 for scattered)
@@ -17,6 +17,8 @@ Changelog for sg3_utils-1.43 [20180716] [svn: r784]
     - add --quick option to skip reconsideration time
     - extend --wait timeout to 40 hours for disk sizes
       > 4 TB and 80 hours if > 8 TB
+    - when changing block size allow for Mode Select
+      rejecting SP=1 (Save Page): repeat with SP=0
   - sg_decode sense: add --cdb and --err=ES options
   - sg_ses: handle 2 bit EIIOE field in aes dpage
     - increase join array size from 260 to 520 elements 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ sg3-utils (1.43-0.1) unstable; urgency=low
 
   * New upstream version
 
- -- Douglas Gilbert <dgilbert@interlog.com>  Sun, 15 Jul 2018 12:00:00 -0400
+ -- Douglas Gilbert <dgilbert@interlog.com>  Mon, 16 Jul 2018 17:00:00 -0400
 
 sg3-utils (1.42-0.1) unstable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ sg3-utils (1.43-0.1) unstable; urgency=low
 
   * New upstream version
 
- -- Douglas Gilbert <dgilbert@interlog.com>  Fri, 06 Jul 2018 12:00:00 -0400
+ -- Douglas Gilbert <dgilbert@interlog.com>  Sun, 15 Jul 2018 12:00:00 -0400
 
 sg3-utils (1.42-0.1) unstable; urgency=low
 

--- a/doc/sg3_utils.8
+++ b/doc/sg3_utils.8
@@ -32,10 +32,12 @@ A good overview of various SCSI standards can be seen in
 http://www.t10.org/scsi\-3.htm with the SCSI command sets in the upper part
 of the diagram. The highest level (i.e. most abstract) document is the SCSI
 Architecture Model (SAM) with SAM\-5 being the most recent standard (ANSI
-INCITS 447\-2008) although SAM\-5 should be released soon. SCSI commands in
-common with all device types can be found in SPC of which SPC\-5 is the
-latest major version. Block device specific commands (e.g. as used by disks)
-are in SBC, those for tape drives in SSC and those for CD/DVD/BD drives in
+INCITS 515\-2016) with the most recent draft being SAM\-6 revision 4 . SCSI
+commands in common with all device types can be found in SCSI Primary
+Commands (SPC) of which SPC\-4 is the most recent standard (ANSI INCITS
+513-2015). The most recent SPC draft is SPC\-5 revision 19. Block device
+specific commands (e.g. as used by disks) are in SBC, those for tape drives
+in SSC, those for SCSI enclosures in SES and those for CD/DVD/BD drives in
 MMC.
 .PP
 It is becoming more common to control ATA disks with the SCSI command set.

--- a/doc/sg_format.8
+++ b/doc/sg_format.8
@@ -1,4 +1,4 @@
-.TH SG_FORMAT "8" "May 2018" "sg3_utils\-1.43" SG3_UTILS
+.TH SG_FORMAT "8" "July 2018" "sg3_utils\-1.43" SG3_UTILS
 .SH NAME
 sg_format \- format, resize a SCSI disk or format a tape
 .SH SYNOPSIS
@@ -133,20 +133,22 @@ utilities (e.g. sg_turs(8) or sg_requests(8)). This option and \fI\-\-wait\fR
 are mutually exclusive.
 .TP
 \fB\-t\fR, \fB\-\-ffmt\fR=\fIFFMT\fR
-\fIFFMT\fR is placed in a field of the same name in the FORMAT UNIT cdb.
-The field was introduced in SBC\-4 revision 10. The default value is 0 which
-implies the former action which is typically to overwrite to all blocks on the
-\fIDEVICE\fR. That can take a long time (e.g. with hard disks over 10 TB in
-size).
+\fIFFMT\fR (fast format) is placed in a field of the same name in the FORMAT
+UNIT cdb. The field was introduced in SBC\-4 revision 10. The default value
+is 0 which implies the former action which is typically to overwrite to all
+blocks on the \fIDEVICE\fR. That can take a long time (e.g. with hard disks
+over 10 TB in size).
 .br
 \fIFFMT\fR has values 1 and 2 for fast format with 3 being reserved
-currently. The difference between 1 and 2 concerns read operations on LBAs to
-which no data has been written to, after the fast format. When \fIFFMT\fR
-is 1 the read operation should return "unspecified logical block data" and
-complete without error. When \fIFFMT\fR is 2 the read operation may
-yield check condition status with a sense key set to hardware error, medium
-error or command aborted. See SBC\-4 revision 10 section 4.35 for more
-details.
+currently. These two values include this description: "The device server
+initializes the medium ... without overwriting the medium (i.e. resources
+for managing medium access are initialized and the medium is not written)".
+The difference between 1 and 2 concerns read operations on LBAs to which no
+data has been written to, after the fast format. When \fIFFMT\fR is 1 the
+read operation should return "unspecified logical block data" and complete
+without error. When \fIFFMT\fR is 2 the read operation may yield check
+condition status with a sense key set to hardware error, medium error or
+command aborted. See SBC\-4 revision 10 section 4.35 for more details.
 .TP
 \fB\-f\fR, \fB\-\-fmtpinfo\fR=\fIFPI\fR
 sets the FMTPINFO field in the FORMAT UNIT cdb to a value between 0 and 3.
@@ -201,6 +203,12 @@ parameters (e.g. when '\-\-pie=PIE' is greater than zero).
 \fIMP\fR is a mode page number (0 to 62 inclusive) that will be used for
 reading and perhaps changing the device logical block size. The default
 is 1 which is the Read\-Write Error Recovery mode page.
+.br
+Preferably the chosen (or default) mode page should be saveable (i.e.
+accept the SP bit set in the MODE SELECT command used when the logical
+block size is being changed). Recent version of this utility will retry a
+MODE SELECT if the SP=1 variant fails with a sense key of ILLEGAL REQUEST.
+The retry that same MODE SELECT command with SP=0 .
 .TP
 \fB\-P\fR, \fB\-\-pfu\fR=\fIPFU\fR
 sets the "Protection Field Usage" field in the parameter block associated
@@ -285,7 +293,7 @@ format; 1 to partition a volume and 2 to do a default format then partition.
 where \fISECS\fR is the FORMAT UNIT or FORMAT MEDIUM command timeout in
 seconds. \fISECS\fR will only be used if it exceeds the internal timeout
 which is 20 seconds if the IMMED bit is set and 72000 seconds (20 hours)
-or higher if the IMMED bit is not set. If the didk unit exceeds 4 TB then
+or higher if the IMMED bit is not set. If the disk size exceeds 4 TB then
 the timeout value is increased to 144000 seconds (40 hours). And if it is
 greater than 8 TB then the timeout value is increased to 288000 seconds (80
 hours). If the timeout is exceeded then the operating system will typically

--- a/doc/sg_ses.8
+++ b/doc/sg_ses.8
@@ -1,4 +1,4 @@
-.TH SG_SES "8" "March 2018" "sg3_utils\-1.43" SG3_UTILS
+.TH SG_SES "8" "July 2018" "sg3_utils\-1.43" SG3_UTILS
 .SH NAME
 sg_ses \- access a SCSI Enclosure Services (SES) device
 .SH SYNOPSIS
@@ -629,6 +629,9 @@ enclosure) for enclosure (including RAID) status and control. SCSI devices
 that support SAF\-TE report "Processor" peripheral device type (0x3) in their
 INQUIRY response. See the sg_safte utility in this package or the
 safte\-monitor utility on the Internet.
+.PP
+The internal join array is statically allocated and its size is controlled
+by the MX_JOIN_ROWS define. Its current value is 520.
 .SH EXAMPLES
 Examples can also be found at http://sg.danny.cz/sg/sg_ses.html
 .PP

--- a/examples/Makefile.freebsd
+++ b/examples/Makefile.freebsd
@@ -8,10 +8,10 @@ MANDIR=$(DESTDIR)/$(PREFIX)/man
 # the default C compiler is clang. Swap the comment marks (lines starting
 # with '#') on the next 4 (non-blank) lines.
 # CC = gcc
-CC = clang
+# CC = clang
 
 # LD = gcc
-LD = clang
+# LD = clang
 
 
 EXECS = sg_simple5
@@ -49,7 +49,7 @@ clean:
 	/bin/rm -f *.o $(EXECS) $(EXTRAS) core .depend
 
 sg_simple5: sg_simple5.o $(D_FILES)
-	$(LD) -o $@ $(LDFLAGS) $@.o $(D_FILES)
+	$(CC) -o $@ $(LDFLAGS) $@.o $(D_FILES)
 
 
 install: $(EXECS)

--- a/lib/sg_lib.c
+++ b/lib/sg_lib.c
@@ -1910,9 +1910,9 @@ bool sg_exit2str(int exit_status, bool longer, int b_len, char *b)
     b[0] = '\0';
     if (exit_status < 0)
         return false;
-    else if ((0 == exit_status) || (SG_LIB_OK_FALSE)) {
+    else if ((0 == exit_status) || (SG_LIB_OK_FALSE == exit_status)) {
         if (longer)
-            snprintf(b, b_len, "%s", ess->name);
+            goto fini;
         return true;
     }
 
@@ -1926,6 +1926,7 @@ bool sg_exit2str(int exit_status, bool longer, int b_len, char *b)
                  exit_status - 128);
         return true;
     }
+fini:
     for ( ; ess->name; ++ess) {
         if (exit_status == ess->value)
             break;
@@ -1946,7 +1947,7 @@ sg_if_can2fp(const char * leadin, int exit_status, FILE * fp)
     char b[256];
     const char * s = leadin ? leadin : "";
 
-    if ((0 == exit_status) || (SG_LIB_OK_FALSE))
+    if ((0 == exit_status) || (SG_LIB_OK_FALSE == exit_status))
         return true;    /* don't print anything */
     else if (sg_exit2str(exit_status, false, sizeof(b), b)) {
         fprintf(fp, "%s%s\n", s, b);

--- a/scripts/rescan-scsi-bus.sh
+++ b/scripts/rescan-scsi-bus.sh
@@ -376,7 +376,7 @@ idlist ()
 
   oldlist=$(ls /sys/class/scsi_device/ | sed -n "s/${host}:${channel}:\([0-9]*:[0-9]*\)/\1/p" | uniq)
   # Rescan LUN 0 to check if we found new targets
-  echo "${channel} - 0" > /sys/class/scsi_host/host${host}/scan
+  echo "${channel} - -" > /sys/class/scsi_host/host${host}/scan
   newlist=$(ls /sys/class/scsi_device/ | sed -n "s/${host}:${channel}:\([0-9]*:[0-9]*\)/\1/p" | uniq)
   for newid in $newlist ; do
     oldid=$newid

--- a/sg3_utils.spec
+++ b/sg3_utils.spec
@@ -80,7 +80,7 @@ fi
 %{_libdir}/*.la
 
 %changelog
-* Sun Jul 15 2018 - dgilbert at interlog dot com
+* Mon Jul 16 2018 - dgilbert at interlog dot com
 - track t10 changes
   * sg3_utils-1.43
 

--- a/sg3_utils.spec
+++ b/sg3_utils.spec
@@ -80,7 +80,7 @@ fi
 %{_libdir}/*.la
 
 %changelog
-* Fri Jul 06 2018 - dgilbert at interlog dot com
+* Sun Jul 15 2018 - dgilbert at interlog dot com
 - track t10 changes
   * sg3_utils-1.43
 

--- a/src/sg_dd.c
+++ b/src/sg_dd.c
@@ -62,7 +62,7 @@
 #include "sg_unaligned.h"
 #include "sg_pr2serr.h"
 
-static const char * version_str = "6.02 20180705";
+static const char * version_str = "6.03 20180723";
 
 
 #define ME "sg_dd: "
@@ -1603,7 +1603,7 @@ main(int argc, char * argv[])
                 pr2serr("Second IFILE argument??\n");
                 return SG_LIB_SYNTAX_ERROR;
             } else
-                strncpy(inf, buf, INOUTF_SZ);
+                strncpy(inf, buf, INOUTF_SZ - 1);
         } else if (0 == strcmp(key, "iflag")) {
             if (process_flags(buf, &iflag)) {
                 pr2serr(ME "bad argument to 'iflag='\n");
@@ -1619,13 +1619,13 @@ main(int argc, char * argv[])
                 pr2serr("Second OFILE argument??\n");
                 return SG_LIB_CONTRADICT;
             } else
-                strncpy(outf, buf, INOUTF_SZ);
+                strncpy(outf, buf, INOUTF_SZ - 1);
         } else if (strcmp(key, "of2") == 0) {
             if ('\0' != out2f[0]) {
                 pr2serr("Second OFILE2 argument??\n");
                 return SG_LIB_CONTRADICT;
             } else
-                strncpy(out2f, buf, INOUTF_SZ);
+                strncpy(out2f, buf, INOUTF_SZ - 1);
         } else if (0 == strcmp(key, "oflag")) {
             if (process_flags(buf, &oflag)) {
                 pr2serr(ME "bad argument to 'oflag='\n");

--- a/src/sg_decode_sense.c
+++ b/src/sg_decode_sense.c
@@ -28,9 +28,9 @@
 #include "sg_unaligned.h"
 
 
-static const char * version_str = "1.18 20180626";
+static const char * version_str = "1.19 20180714";
 
-#define MAX_SENSE_LEN 1024 /* max descriptor format actually: 256+8 */
+#define MAX_SENSE_LEN 1024 /* max descriptor format actually: 255+8 */
 
 static struct option long_options[] = {
     {"binary", required_argument, 0, 'b'},
@@ -428,7 +428,6 @@ write2wfn(FILE * fp, struct opts_t * op)
 int
 main(int argc, char *argv[])
 {
-    bool ok;
     int k, err;
     int ret = 0;
     unsigned int ui;
@@ -476,8 +475,7 @@ main(int argc, char *argv[])
         char d[128];
         const int dlen = sizeof(d);
 
-        ok = sg_exit2str(op->es_val, op->verbose > 1, dlen, d);
-        if (! ok)
+        if (! sg_exit2str(op->es_val, op->verbose > 1, dlen, d))
             snprintf(d, dlen, "Unable to decode exit status %d", op->es_val);
         if (1 & op->verbose) /* odd values of verbose print to stderr */
             pr2serr("%s\n", d);

--- a/src/sg_map26.c
+++ b/src/sg_map26.c
@@ -45,7 +45,7 @@
 #endif
 #include "sg_lib.h"
 
-static const char * version_str = "1.15 20171019";
+static const char * version_str = "1.16 20180724";
 
 #define ME "sg_map26: "
 
@@ -60,8 +60,8 @@ static const char * version_str = "1.15 20171019";
 #define NT_REG 8
 #define NT_DIR 9
 
-#define NAME_LEN_MAX 260
-#define D_NAME_LEN_MAX 516
+#define NAME_LEN_MAX 256
+#define D_NAME_LEN_MAX 520
 
 #ifndef SCSI_CHANGER_MAJOR
 #define SCSI_CHANGER_MAJOR 86
@@ -344,9 +344,8 @@ nd_match_scandir_select(const struct dirent * s)
         }
         if ((! symlnk) && (-1 == nd_match.majj) && (-1 == nd_match.minn))
                 return 1;
-        strncpy(name, nd_match.dir_name, NAME_LEN_MAX);
-        strcat(name, "/");
-        strncat(name, s->d_name, NAME_LEN_MAX);
+        snprintf(name, sizeof(name), "%.*s/%.*s", NAME_LEN_MAX,
+                 nd_match.dir_name, NAME_LEN_MAX, s->d_name);
         memset(&st, 0, sizeof(st));
         if (stat(name, &st) < 0)
                 return 0;
@@ -374,7 +373,7 @@ list_matching_nodes(const char * dir_name, int file_type, int majj, int minn,
         struct dirent ** namelist;
         int num, k;
 
-        strncpy(nd_match.dir_name, dir_name, D_NAME_LEN_MAX);
+        strncpy(nd_match.dir_name, dir_name, D_NAME_LEN_MAX - 1);
         nd_match.file_type = file_type;
         nd_match.majj = majj;
         nd_match.minn = minn;
@@ -1066,7 +1065,7 @@ main(int argc, char * argv[])
 
                 switch (c) {
                 case 'd':
-                        strncpy(device_dir, optarg, sizeof(device_dir));
+                        strncpy(device_dir, optarg, sizeof(device_dir) - 1);
                         do_dev_dir = true;
                         break;
                 case 'g':

--- a/src/sg_read.c
+++ b/src/sg_read.c
@@ -53,7 +53,7 @@
 #include "sg_pr2serr.h"
 
 
-static const char * version_str = "1.32 20180523";
+static const char * version_str = "1.33 20180724";
 
 #define DEF_BLOCK_SIZE 512
 #define DEF_BLOCKS_PER_TRANSFER 128
@@ -487,7 +487,7 @@ main(int argc, char * argv[])
         else if (0 == strcmp(key,"fua"))
             fua = !! sg_get_num(buf);
         else if (strcmp(key,"if") == 0)
-            strncpy(inf, buf, INF_SZ);
+            strncpy(inf, buf, INF_SZ - 1);
         else if (0 == strcmp(key,"mmap"))
             do_mmap = !! sg_get_num(buf);
         else if (0 == strcmp(key,"no_dxfer"))
@@ -495,7 +495,7 @@ main(int argc, char * argv[])
         else if (0 == strcmp(key,"odir"))
             do_odir = !! sg_get_num(buf);
         else if (strcmp(key,"of") == 0)
-            strncpy(outf, buf, INF_SZ);
+            strncpy(outf, buf, INF_SZ - 1);
         else if (0 == strcmp(key,"skip")) {
             skip = sg_get_llnum(buf);
             if (-1 == skip) {

--- a/src/sg_ses.c
+++ b/src/sg_ses.c
@@ -36,7 +36,7 @@
  * commands tailored for SES (enclosure) devices.
  */
 
-static const char * version_str = "2.41 20180716";    /* ses4r02 */
+static const char * version_str = "2.42 20180724";    /* ses4r02 */
 
 #define MX_ALLOC_LEN ((64 * 1024) - 4)  /* max allowable for big enclosures */
 #define MX_ELEM_HDR 1024
@@ -984,6 +984,7 @@ parse_index(struct opts_t *op)
     const char * cc3p;
     const struct element_type_t * etp;
     char b[64];
+    const int blen = sizeof(b);
 
     op->ind_given = true;
     n2 = 0;
@@ -1011,20 +1012,19 @@ parse_index(struct opts_t *op)
         if (n2 > 0)
             op->ind_indiv_last = n2;
         n = cp - op->index_str;
-        if (n >= (int)sizeof(b)) {
+        if (n >= (blen - 1)) {
             pr2serr("bad argument to '--index', string prior to comma too "
                     "long\n");
             return SG_LIB_SYNTAX_ERROR;
         }
     } else {    /* no comma found in index_str */
         n = strlen(op->index_str);
-        if (n >= (int)sizeof(b)) {
+        if (n >= (blen - 1)) {
             pr2serr("bad argument to '--index', string too long\n");
             return SG_LIB_SYNTAX_ERROR;
         }
     }
-    strncpy(b, op->index_str, n);
-    b[n] = '\0';
+    snprintf(b, blen, "%.*s", n, op->index_str);
     if (0 == strcmp("-1", b)) {
         if (cp) {
             pr2serr("bad argument to '--index', unexpected '-1' type header "

--- a/src/sg_ses.c
+++ b/src/sg_ses.c
@@ -36,7 +36,7 @@
  * commands tailored for SES (enclosure) devices.
  */
 
-static const char * version_str = "2.40 20180628";    /* ses4r02 */
+static const char * version_str = "2.41 20180716";    /* ses4r02 */
 
 #define MX_ALLOC_LEN ((64 * 1024) - 4)  /* max allowable for big enclosures */
 #define MX_ELEM_HDR 1024
@@ -45,9 +45,11 @@ static const char * version_str = "2.40 20180628";    /* ses4r02 */
 #define MIN_DATA_IN_SZ 8192     /* use max(MIN_DATA_IN_SZ, op->maxlen) for
                                  * the size of data_arr */
 #define MX_DATA_IN_LINES (16 * 1024)
-#define MX_JOIN_ROWS 260        /* element index fields in dpages are only 8
+#define MX_JOIN_ROWS 520        /* element index fields in dpages are only 8
                                  * bit, and index 0xff (255) is sometimes used
-                                 * for 'not applicable' */
+                                 * for 'not applicable'. However this limit
+                                 * can bypassed with sub-enclosure numbers.
+                                 * So try higher figure. */
 #define MX_DATA_IN_DESCS 32
 #define NUM_ACTIVE_ET_AESP_ARR 32
 
@@ -207,7 +209,7 @@ struct type_desc_hdr_t {
  * page. Note that the array of these struct instances is built such that
  * the array index is equal to the 'ei_ioe' (element index that includes
  * overall elements). */
-struct join_row_t {
+struct join_row_t {  /* this struct is 72 bytes long on Intel "64" bit arch */
     int th_i;           /* type header index (origin 0) */
     int indiv_i;        /* individual (element) index, -1 for overall
                          * instance, otherwise origin 0 */

--- a/src/sg_write_long.c
+++ b/src/sg_write_long.c
@@ -35,7 +35,7 @@
 #include "sg_cmds_extra.h"
 #include "sg_pr2serr.h"
 
-static const char * version_str = "1.20 20180628";
+static const char * version_str = "1.21 20180723";
 
 
 #define MAX_XFER_LEN (15 * 1024)
@@ -139,7 +139,8 @@ main(int argc, char * argv[])
             usage();
             return 0;
         case 'i':
-            strncpy(file_name, optarg, sizeof(file_name));
+            strncpy(file_name, optarg, sizeof(file_name) - 1);
+            file_name[sizeof(file_name) - 1] = '\0';
             break;
         case 'l':
             ll = sg_get_llnum(optarg);

--- a/src/sg_write_same.c
+++ b/src/sg_write_same.c
@@ -31,7 +31,7 @@
 #include "sg_unaligned.h"
 #include "sg_pr2serr.h"
 
-static const char * version_str = "1.25 20180628";
+static const char * version_str = "1.26 20180723";
 
 
 #define ME "sg_write_same: "
@@ -357,7 +357,8 @@ main(int argc, char * argv[])
             usage();
             return 0;
         case 'i':
-            strncpy(op->ifilename, optarg, sizeof(op->ifilename));
+            strncpy(op->ifilename, optarg, sizeof(op->ifilename) - 1);
+            op->ifilename[sizeof(op->ifilename) - 1] = '\0';
             if_given = true;
             break;
         case 'l':

--- a/src/sginfo.c
+++ b/src/sginfo.c
@@ -122,7 +122,7 @@
 #define _GNU_SOURCE 1
 #endif
 
-static const char * version_str = "2.40 [20180219]";
+static const char * version_str = "2.41 [20180724]";
 
 #include <stdio.h>
 #include <string.h>
@@ -3390,7 +3390,7 @@ static Sg_map sg_map_arr[MAX_SG_DEVS + 1];
 static void
 show_devices(int raw)
 {
-    int k, j, fd, err, bus;
+    int k, j, fd, err, bus, n;
     My_scsi_idlun m_idlun;
     char name[MDEV_NAME_SZ];
     char dev_name[MDEV_NAME_SZ + 6];
@@ -3462,8 +3462,12 @@ show_devices(int raw)
         sg_map_arr[j].channel = (m_idlun.mux4 >> 16) & 0xff;
         sg_map_arr[j].lun = (m_idlun.mux4 >> 8) & 0xff;
         sg_map_arr[j].target_id = m_idlun.mux4 & 0xff;
-        tmpptr=(char *)malloc(strlen(dev_name)+1);
-        strncpy(tmpptr,dev_name,strlen(dev_name)+1);
+        n = strlen(dev_name);
+        /* memory leak ... no free()s for this malloc() */
+        tmpptr = (char *)malloc(n + 1);
+        snprintf(tmpptr, n + 1, "%.*s", n, dev_name);
+        /* strncpy(tmpptr,dev_name,strlen(dev_name)+1); */
+
         sg_map_arr[j].dev_name = tmpptr;
 #if 0
         printf("[scsi%d ch=%d id=%d lun=%d %s] ", sg_map_arr[j].bus,

--- a/src/sgm_dd.c
+++ b/src/sgm_dd.c
@@ -66,7 +66,7 @@
 #include "sg_pr2serr.h"
 
 
-static const char * version_str = "1.58 20180705";
+static const char * version_str = "1.59 20180724";
 
 #define DEF_BLOCK_SIZE 512
 #define DEF_BLOCKS_PER_TRANSFER 128
@@ -752,7 +752,7 @@ main(int argc, char * argv[])
 
     for (k = 1; k < argc; k++) {
         if (argv[k])
-            strncpy(str, argv[k], STR_SZ);
+            snprintf(str, STR_SZ, "%s", argv[k]);
         else
             continue;
         for (key = str, buf = key; *buf && *buf != '=';)
@@ -807,7 +807,7 @@ main(int argc, char * argv[])
                 pr2serr("Second 'if=' argument??\n");
                 return SG_LIB_CONTRADICT;
             } else
-                strncpy(inf, buf, INOUTF_SZ);
+                snprintf(inf, INOUTF_SZ, "%s", buf);
         } else if (0 == strcmp(key, "iflag")) {
             if (process_flags(buf, &in_flags)) {
                 pr2serr(ME "bad argument to 'iflag'\n");
@@ -818,7 +818,7 @@ main(int argc, char * argv[])
                 pr2serr("Second 'of=' argument??\n");
                 return SG_LIB_CONTRADICT;
             } else
-                strncpy(outf, buf, INOUTF_SZ);
+                snprintf(outf, INOUTF_SZ, "%s", buf);
         } else if (0 == strcmp(key, "oflag")) {
             if (process_flags(buf, &out_flags)) {
                 pr2serr(ME "bad argument to 'oflag'\n");

--- a/src/sgp_dd.c
+++ b/src/sgp_dd.c
@@ -60,7 +60,7 @@
 #include "sg_pr2serr.h"
 
 
-static const char * version_str = "5.67 20180627";
+static const char * version_str = "5.68 20180724";
 
 #define DEF_BLOCK_SIZE 512
 #define DEF_BLOCKS_PER_TRANSFER 128
@@ -1253,7 +1253,7 @@ main(int argc, char * argv[])
                 pr2serr("Second 'if=' argument??\n");
                 return SG_LIB_SYNTAX_ERROR;
             } else
-                strncpy(inf, buf, INOUTF_SZ);
+                snprintf(inf, INOUTF_SZ, "%s", buf);
         } else if (0 == strcmp(key, "iflag")) {
             if (process_flags(buf, &rcoll.in_flags)) {
                 pr2serr("%sbad argument to 'iflag='\n", my_name);
@@ -1270,7 +1270,7 @@ main(int argc, char * argv[])
                 pr2serr("Second 'of=' argument??\n");
                 return SG_LIB_SYNTAX_ERROR;
             } else
-                strncpy(outf, buf, INOUTF_SZ);
+                snprintf(outf, INOUTF_SZ, "%s", buf);
         } else if (0 == strcmp(key, "oflag")) {
             if (process_flags(buf, &rcoll.out_flags)) {
                 pr2serr("%sbad argument to 'oflag='\n", my_name);

--- a/testing/Makefile.freebsd
+++ b/testing/Makefile.freebsd
@@ -8,10 +8,10 @@ MANDIR=$(DESTDIR)/$(PREFIX)/man
 # the default C compiler is clang. Swap the comment marks (lines starting
 # with '#') on the next 4 (non-blank) lines.
 # CC = gcc
-CC = clang
+# CC = clang
 
 # LD = gcc
-LD = clang
+# LD = clang
 
 EXECS = sg_sense_test sg_chk_asc sg_tst_nvme tst_sg_lib
 	
@@ -54,17 +54,17 @@ clean:
 	/bin/rm -f *.o $(EXECS) $(EXTRAS) core .depend
 
 sg_sense_test: sg_sense_test.o $(D_FILES)
-	$(LD) -o $@ $(LDFLAGS) $@.o $(D_FILES)
+	$(CC) -o $@ $(LDFLAGS) $@.o $(D_FILES)
 
 # building sg_chk_asc depends on a prior successful make in ../lib
 sg_chk_asc: sg_chk_asc.o $(D_FILES)
-	$(LD) -o $@ $(LDFLAGS) $@.o $(D_FILES)
+	$(CC) -o $@ $(LDFLAGS) $@.o $(D_FILES)
 
 sg_tst_nvme: sg_tst_nvme.o $(D_FILES)
-	$(LD) -o $@ $(LDFLAGS) $@.o $(D_FILES)
+	$(CC) -o $@ $(LDFLAGS) $@.o $(D_FILES)
 
 tst_sg_lib: tst_sg_lib.o $(D_FILES)
-	$(LD) -o $@ $(LDFLAGS) $@.o $(D_FILES)
+	$(CC) -o $@ $(LDFLAGS) $@.o $(D_FILES)
 
 install: $(EXECS)
 	install -d $(INSTDIR)

--- a/testing/tst_sg_lib.c
+++ b/testing/tst_sg_lib.c
@@ -19,7 +19,7 @@
 
 #include <time.h>
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && ! defined(SG_LIB_FREEBSD)
 #include <byteswap.h>
 #endif
 
@@ -42,7 +42,7 @@
  * related to snprintf().
  */
 
-static const char * version_str = "1.11 20180706";
+static const char * version_str = "1.11 20180715";
 
 
 #define MAX_LINE_LEN 1024
@@ -160,26 +160,27 @@ usage()
             "[--printf]\n"
             "                  [--sense] [--unaligned] [--verbose] "
             "[--version]\n"
-#ifdef __GNUC__
-            "  where: --byteswap=B|-b B    B is 16, 32 or 64; tests "
-            "NUM byteswaps\n"
-            "                              compared to sg_unaligned "
+            "  where:\n"
+#if defined(__GNUC__) && ! defined(SG_LIB_FREEBSD)
+            "    --byteswap=B|-b B    B is 16, 32 or 64; tests NUM "
+            "byteswaps\n"
+            "                         compared to sg_unaligned "
             "equivalent\n"
-            "         --exit|-e          test exit status strings\n"
+            "    --exit|-e          test exit status strings\n"
 #else
-            "  where: --exit|-e          test exit status strings\n"
+            "    --exit|-e          test exit status strings\n"
 #endif
-            "         --help|-h          print out usage message\n"
-            "         --hex2|-H          test hex2* variants\n"
-            "         --leadin=STR|-l STR    every line output by --sense "
+            "    --help|-h          print out usage message\n"
+            "    --hex2|-H          test hex2* variants\n"
+            "    --leadin=STR|-l STR    every line output by --sense "
             "should\n"
-            "                                be prefixed by STR\n"
-            "         --num=NUM|-n NUM    number of iterations (def=1)\n"
-            "         --printf|-p        test library printf variants\n"
-            "         --sense|-s         test sense data handling\n"
-            "         --unaligned|-u     test unaligned data handling\n"
-            "         --verbose|-v       increase verbosity\n"
-            "         --version|-V       print version string and exit\n\n"
+            "                           be prefixed by STR\n"
+            "    --num=NUM|-n NUM    number of iterations (def=1)\n"
+            "    --printf|-p        test library printf variants\n"
+            "    --sense|-s         test sense data handling\n"
+            "    --unaligned|-u     test unaligned data handling\n"
+            "    --verbose|-v       increase verbosity\n"
+            "    --version|-V       print version string and exit\n\n"
             "Test various parts of sg_lib, see options. Sense data tests "
             "overlap\nsomewhat with examples/sg_sense_test .\n"
            );
@@ -297,6 +298,8 @@ main(int argc, char * argv[])
     }
 
     if (do_exit_status) {
+        ++did_something;
+
         printf("Test Exit Status strings (add -v for long version):\n");
         printf("  No error (es=0): %s\n",
                sg_get_category_sense_str(0, b_len, b, vb));
@@ -315,6 +318,7 @@ main(int argc, char * argv[])
         printf("%s\n", get_exit_status_str(8, (vb > 0), b_len, b));
         printf("%s\n", get_exit_status_str(25, (vb > 0), b_len, b));
         printf("%s\n", get_exit_status_str(33, (vb > 0), b_len, b));
+        printf("%s\n", get_exit_status_str(36, (vb > 0), b_len, b));
         printf("%s\n", get_exit_status_str(48, (vb > 0), b_len, b));
         printf("%s\n", get_exit_status_str(50, (vb > 0), b_len, b));
         printf("%s\n", get_exit_status_str(51, (vb > 0), b_len, b));
@@ -551,7 +555,7 @@ main(int argc, char * argv[])
         printf("  u64r[v=8 bytes]=0x%" PRIx64 "\n\n", u64r);
     }
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && ! defined(SG_LIB_FREEBSD)
     if (byteswap_sz > 0) {
         uint32_t elapsed_msecs;
         uint16_t count16 = 0;

--- a/utils/Makefile.freebsd
+++ b/utils/Makefile.freebsd
@@ -4,8 +4,8 @@ PREFIX=/usr/local
 INSTDIR=$(DESTDIR)/$(PREFIX)/bin
 MANDIR=$(DESTDIR)/$(PREFIX)/man
 
-CC = gcc
-LD = gcc
+CC = clang
+LD = clang
 
 EXECS = hxascdmp
 


### PR DESCRIPTION
By scanning for LUN 0 only, we may encounter a device that the
kernel won't add (e.g. peripheral device type 31) and which may
thus never appear in sysfs for us to use for REPORT LUNS. That
causes LUN additions for such devices to be missed by
"rescan-iscsi-bus.sh -a".

Acked-by: Douglas Gilbert <dgilbert@interlog.com>
