### PR TITLE
rescan-scsi-bus.sh: use LUN wildcard in idlist

### DIFF
--- a/scripts/rescan-scsi-bus.sh
+++ b/scripts/rescan-scsi-bus.sh
@@ -366,7 +366,7 @@ idlist ()
 
   oldlist=$(ls /sys/class/scsi_device/ | sed -n "s/${host}:${channel}:\([0-9]*:[0-9]*\)/\1/p" | uniq)
   # Rescan LUN 0 to check if we found new targets
-  echo "${channel} - 0" > /sys/class/scsi_host/host${host}/scan
+  echo "${channel} - -" > /sys/class/scsi_host/host${host}/scan
   newlist=$(ls /sys/class/scsi_device/ | sed -n "s/${host}:${channel}:\([0-9]*:[0-9]*\)/\1/p" | uniq)
   for newid in $newlist ; do
     oldid=$newid


### PR DESCRIPTION
By scanning for LUN 0 only, we may encounter a device that the
kernel won't add (e.g. peripheral device type 31) and which may
thus never appear in sysfs for us to use for REPORT LUNS. That
causes LUN additions for such devices to be missed by
"rescan-iscsi-bus.sh -a".

This is contained in SVN r795 upstream.