### PR TITLE
sg_turs: fix help invocation in the old mode

### DIFF
--- a/src/sg_turs.c
+++ b/src/sg_turs.c
@@ -252,7 +252,7 @@ old_parse_cmd_line(struct opts_t * op, int argc, char * argv[])
                     op->version_given = true;
                     break;
                 case '?':
-                    usage_old();
+                    ++op->do_help;
                     return 0;
                 default:
                     jmp_out = true;


### PR DESCRIPTION
In the old mode the usage was printed out twice when called by `sg_turs -O -?`.