### PR TITLE
sg_raw: do not print error about device not specified on version request

### DIFF
--- a/src/sg_raw.c
+++ b/src/sg_raw.c
@@ -440,6 +440,13 @@ parse_cmd_line(struct opts_t * op, int argc, char *argv[])
         }
     }
 
+    if (op->version_given
+#ifdef DEBUG
+       && ! op->verbose_given
+#endif
+       )
+        return 0;
+
     if (optind >= argc) {
         pr2serr("No device specified\n\n");
         return SG_LIB_SYNTAX_ERROR;


### PR DESCRIPTION
Small commandline option parser fix. Tried to preserve correct behaviour when `DEBUG` is enabled.