### PR TITLE
fc_wwpn_id: add condition to FC_TARGET_LUN return

### DIFF
--- a/scripts/fc_wwpn_id
+++ b/scripts/fc_wwpn_id
@@ -38,7 +38,9 @@ while [ -n "$d" ] ; do
     esac
 done
 
-echo "FC_TARGET_LUN=$target_lun"
+if [ -n "$rport_wwpn" ] || [ -n "$host_wwpn" ] ; then
+    echo "FC_TARGET_LUN=$target_lun"
+fi
 
 if [ -n "$rport_wwpn" ] ; then
     echo "FC_TARGET_WWPN=$rport_wwpn"


### PR DESCRIPTION
If there is no relevant fc_remote_port or fc_host found, there is no need to return the target_lun number.  Returning with no condition causes a FC_TARGET_LUN value to be present in the udev database for devices that are not fibre attached.  Add condition to check.