### PR TITLE
55-scsi-sg3_id.rules: ignore USB block devices by default

### DIFF
--- a/scripts/55-scsi-sg3_id.rules
+++ b/scripts/55-scsi-sg3_id.rules
@@ -28,6 +28,10 @@ ENV{DEVTYPE}=="partition", ENV{ID_SCSI}=="1", GOTO="compat"
 # Handle non-SCSI devices that implement SCSI inquiry
 KERNEL=="cciss*", ENV{DEVTYPE}=="disk", GOTO="sg_inquiry"
 
+# Ignore USB block devices as they don't contain VPD 0x80 and 0x83
+# and their SERIAL is calculated from usb_id in persistent-storage rules
+DEVPATH=="*usb*", GOTO="sg3_utils_id_end"
+
 # Ignore everything else except sd/sr
 KERNEL!="sd*[!0-9]|sr*", GOTO="sg3_utils_id_end"
 


### PR DESCRIPTION
(Issue 1)

ACTION (add) for some USB devices gets delayed for a long time because
of bad sg_inq commands trying to get, by default, VPDs (0x80, 0x83) from
USB devices that don't support them:

systemd-udevd[1021]: Process '/usr/bin/sg_inq --export --inhex=/sys/block/sdb/device/vpd_pg83 --raw' failed with exit code 15.

For anything depending on USB block device ID_SERIAL attribute, this
*could* be workarounded by a "udevadm settle" if it wasn't for the next
issue.

(Issue 2)

USB ID_SERIAL attribute gets broken if VPDs (0x80, 0x83) aren't
supported by the USB block device. USB serials should fallback to
"usb_id" if no serial is found (60-persistent-storage.rules).

Example:

  Without sg3-utils 55-scsi-sg3_id.rules:

  $ udevadm info --query=all --name=/dev/sdb | grep -i serial
  E: ID_SERIAL=Corsair_Voyager_Mini_3.0_070851D0E490C776-0:0
  E: ID_SERIAL_SHORT=070851D0E490C776

  With 55-scsi-sg3_id.rules:

  $ udevadm info --query=all --name=/dev/sdb | grep -i serial
  E: ID_SERIAL=3
  E: ID_SERIAL_SHORT=2000acde48234567

Only property able to differentiate USB block devices from others, by
the time they are inserted and before "sg_inq" runs is the DEVPATH
containing "usb" string.

This change makes 55-scsi-sg3_id.rules to ignore USB block devices.

Bug: https://bugs.launchpad.net/bugs/1833618

Signed-off-by: Rafael David Tinoco <rafaeldtinoco@ubuntu.com>