### PR TITLE
Recognise uclinux as a linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,7 +111,7 @@ esac
 
 # Define platform-specific symbol.
 AM_CONDITIONAL(OS_FREEBSD, [echo $host_os | grep 'freebsd' > /dev/null])
-AM_CONDITIONAL(OS_LINUX, [echo $host_os | grep '^linux' > /dev/null])
+AM_CONDITIONAL(OS_LINUX, [echo $host_os | grep -E '^(uc)?linux' > /dev/null])
 AM_CONDITIONAL(OS_OSF, [echo $host_os | grep '^osf' > /dev/null])
 AM_CONDITIONAL(OS_SOLARIS, [echo $host_os | grep '^solaris' > /dev/null])
 AM_CONDITIONAL(OS_WIN32_MINGW, [echo $host_os | grep '^mingw' > /dev/null])


### PR DESCRIPTION
Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/sg3_utils/0001-support-uclinux-as-a-linux.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>