### PR TITLE
sg_reset: Add missing `\n` to fix help display

### DIFF
--- a/src/sg_reset.c
+++ b/src/sg_reset.c
@@ -107,7 +107,7 @@ usage(int compat_mode)
     }
     pr2serr("    --no-esc|-N     overrides default action and only does "
             "reset requested\n"
-            "    --no-escalate   The same as --no-esc|-N"
+            "    --no-escalate   The same as --no-esc|-N\n"
             "    --target|-t     target reset. The target holds the DEVICE "
             "and perhaps\n"
             "                    other LUs\n"


### PR DESCRIPTION
Without this: 

```
Usage: sg_reset [--bus] [--device] [--help] [--host] [--no-esc] [--no-escalate] [--target]
                [--verbose] [--version] DEVICE
  where:
    --bus|-b        SCSI bus reset (SPI concept), might be all targets
    --device|-d     device (logical unit) reset
    --help|-h       print usage information then exit
    --host|-H       host (bus adapter: HBA) reset
    --no-esc|-N     overrides default action and only does reset requested
    --no-escalate   The same as --no-esc|-N    --target|-t     target reset. The target holds the DEVICE and perhaps
                    other LUs
    --verbose|-v    increase the level of verbosity
    --version|-V    print version number then exit

Use SG_SCSI_RESET ioctl to send a reset to the host/bus/target/device
along the DEVICE path. The DEVICE itself is known as a logical unit (LU)
in SCSI terminology.
Be warned: if the '-N' option is not given then if '-d' fails then a
target reset ('-t') is instigated. And it '-t' fails then a bus reset
('-b') is instigated. And if '-b' fails then a host reset ('h') is
instigated. It is recommended to use '-N' to stop the reset escalation.
```