### PR TITLE
when do rescan-scsi-bus.sh show all targets in same line

### DIFF
--- a/scripts/rescan-scsi-bus.sh
+++ b/scripts/rescan-scsi-bus.sh
@@ -1337,7 +1337,7 @@ else
   [ -n "$channelsearch" ] && echo -n "channels $channelsearch "
   echo -n "for "
   if [ -n "$idsearch" ] ; then
-    echo -n " SCSI target IDs $idsearch"
+    echo -n " SCSI target IDs" $idsearch
   else
     echo -n " all SCSI target IDs"
   fi


### PR DESCRIPTION
before:
# rescan-scsi-bus.sh
Scanning SCSI subsystem for new devices
Scanning host 0 for  SCSI target IDs 0
1
2
3
4
5
6
7, all LUNs
sg0 changed: LU not available (PQual 3)
OLD: Host: scsi0 Channel: 00 Id: 00 Lun: 00
      Vendor: QEMU     Model: QEMU HARDDISK    Rev: 2.5+
      Type:   Direct-Access                    ANSI SCSI revision: 05

after: 
#rescan-scsi-bus.sh
Scanning SCSI subsystem for new devices
Scanning host 0 for  SCSI target IDs 0 1 2 3 4 5 6 7, all LUNs
sg0 changed: LU not available (PQual 3)
OLD: Host: scsi0 Channel: 00 Id: 00 Lun: 00
      Vendor: QEMU     Model: QEMU HARDDISK    Rev: 2.5+
      Type:   Direct-Access                    ANSI SCSI revision: 05


Signed-off-by: Wu Bo <wubo.linux@gmail.com>