### PR TITLE
sg_stream_ctl : fix the last stram id lost in stream list of GET STRE…

### DIFF
--- a/src/sg_stream_ctl.c
+++ b/src/sg_stream_ctl.c
@@ -451,7 +451,7 @@ main(int argc, char * argv[])
             printf("Number of open streams: %u\n", num_streams);
         }
         maxlen = ((uint32_t)maxlen < param_dl) ? maxlen : (int)param_dl;
-        for (k = 8; k < (maxlen - 4); k += 8) {
+        for (k = 8; k <= (maxlen - 4); k += 8) {
             stream_id = sg_get_unaligned_be16(arr + k + 2);
             if (do_brief)
                 printf("%u\n", stream_id);


### PR DESCRIPTION
- Open three streams which stream ids are 1, 2 and 3
- perform command :  **sg_stream_ctl /dev/sda -g -i 1**

The output is as follows and  the last stream id is lost :
```
Starting at stream id : 1
Number of open streams : 3
Open stream id : 1
Open stream id : 2
```
