### PR TITLE
sg_write_attr

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,9 @@ Each utility has its own version number, date of last change and
 some description at the top of its ".c" file. All utilities in the main
 directory have their own "man" pages. There is also a sg3_utils man page.
 
+Changelog for pre-release sg3_utils-1.48 [20221125]
+  - sg_write_attr: new, supported by tape drives
+
 Changelog for pre-release sg3_utils-1.47 [20210407] [svn: r894]
   - move some hex file from examples to inhex directory
   - add testing/sg_take_snap

--- a/README
+++ b/README
@@ -268,8 +268,8 @@ subdirectory of the sg3_utils package:
     sg_sat_read_gplog, sg_sat_set_features, sg_scan, sg_seek, sg_senddiag,
     sg_ses, sg_ses_microcode, sg_start, sg_stpg, sg_stream_ctl, sg_sync,
     sg_test_rwbuff, sg_timestamp, sg_turs, sg_unmap, sg_verify, sg_vpd,
-    sg_write_buffer, sg_write_long, sg_write_same, sg_write_verify,
-    sg_write_x, sg_wr_mode, sg_xcopy, sg_zone
+    sg_write_attr, sg_write_buffer, sg_write_long, sg_write_same,
+    sg_write_verify, sg_write_x, sg_wr_mode, sg_xcopy, sg_zone
 
 Each of the above utilities depends on header files found in the 'include'
 subdirectory and library code found in the 'lib' subdirectory. Associated
@@ -454,8 +454,8 @@ The more recent utilities that use "getopt_long" only are:
     sg_sat_identify, sg_sat_phy_event, sg_sat_read_gplog,
     sg_sat_set_features, sg_scan(w), sg_seek, sg_ses, sg_ses_microcode,
     sg_stpg, sg_stream_ctl, sg_sync, sg_test_rwbuf, sg_timestamp, sg_unmap,
-    sg_verify, sg_vpd, sg_write_buffer, sg_write_long, sg_write_same,
-    sg_write_verify, sg_write_x, sg_wr_mode, sg_zone
+    sg_verify, sg_vpd, sg_write_attr, sg_write_buffer, sg_write_long,
+    sg_write_same, sg_write_verify, sg_write_x, sg_wr_mode, sg_zone
 
 
 Dangerous code

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -13,8 +13,8 @@ man_MANS = \
 	sg_sat_read_gplog.8 sg_sat_set_features.8 sg_seek.8 sg_senddiag.8 \
 	sg_ses.8 sg_ses_microcode.8 sg_start.8 sg_stpg.8 sg_stream_ctl.8 \
 	sg_sync.8 sg_timestamp.8 sg_turs.8 sg_unmap.8 sg_verify.8 sg_vpd.8 \
-	sg_wr_mode.8 sg_write_buffer.8 sg_write_long.8 sg_write_same.8 \
-	sg_write_verify.8 sg_write_x.8 sg_zone.8
+	sg_wr_mode.8 sg_write_attr.8 sg_write_buffer.8 sg_write_long.8 \
+	sg_write_same.8 sg_write_verify.8 sg_write_x.8 sg_zone.8
 CLEANFILES =
 
 if OS_LINUX

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -294,9 +294,9 @@ man_MANS = scsi_mandat.8 scsi_readcap.8 scsi_ready.8 scsi_satl.8 \
 	sg_sat_set_features.8 sg_seek.8 sg_senddiag.8 sg_ses.8 \
 	sg_ses_microcode.8 sg_start.8 sg_stpg.8 sg_stream_ctl.8 \
 	sg_sync.8 sg_timestamp.8 sg_turs.8 sg_unmap.8 sg_verify.8 \
-	sg_vpd.8 sg_wr_mode.8 sg_write_buffer.8 sg_write_long.8 \
-	sg_write_same.8 sg_write_verify.8 sg_write_x.8 sg_zone.8 \
-	$(am__append_1) $(am__append_3) $(am__append_5)
+	sg_vpd.8 sg_wr_mode.8 sg_write_attr.8 sg_write_buffer.8 \
+	sg_write_long.8 sg_write_same.8 sg_write_verify.8 sg_write_x.8 \
+	sg_zone.8 $(am__append_1) $(am__append_3) $(am__append_5)
 CLEANFILES = $(am__append_2) $(am__append_4) $(am__append_6)
 all: all-am
 

--- a/doc/sg_write_attr.8
+++ b/doc/sg_write_attr.8
@@ -1,0 +1,244 @@
+.TH SG_WRITE_ATTR "8" "November 2022" "sg3_utils\-1.48" SG3_UTILS
+.SH NAME
+sg_write_attr \- send SCSI WRITE ATTRIBUTE command
+.SH SYNOPSIS
+.B sg_write_attr
+[\fI\-\-enumerate\fR] [\fI\-\-element=EA\fR]
+[\fI\-\-help\fR] [\fI\-\-hex\fR] [\fI\-\-in=FN\fR]
+[\fI\-\-lvn=LVN\fR] [\fI\-\-pn=PN\fR] [\fI\-\-raw\fR]
+[\fI\-\-wtc\fR] [\fI\-\-verbose\fR] [\fI\-\-version\fR]
+\fIDEVICE\fR [\fIattribute=value\fR [\fIattribute:value\fR...]]
+.SH DESCRIPTION
+.\" Add any additional description here
+.PP
+Sends a SCSI WRITE ATTRIBUTE command to \fIDEVICE\fR among with attribute-value
+pairs specified in command line arguments or read from the input file.
+This command was introduced in SPC\-3 revision 1 and thus is
+applicable to all SCSI devices. In practice it is used mainly for tape
+systems. This utility is based on the SPC\-5 draft standard, revision
+17 (spc5r17.pdf).
+.SH OPTIONS
+Arguments to long options are mandatory for short options as well.
+.TP
+\fB\-e\fR, \fB\-\-enumerate\fR
+enumerates all known attributes. Attributes include an identifier,
+length, format and a name as defined by T10, with supplementary acronym
+which may be used instead of identifier. Some attributes may also include
+predefined set of values.
+If \fIDEVICE\fR or \fIattribute=value\fR pairs are given then they are ignored.
+.TP
+\fB\-E\fR, \fB\-\-element\fR=\fIEA\fR
+where \fIEA\fR is an element address which is placed in the WRITE ATTRIBUTE
+cdb. This field is only found in SMC\-2 and SMC\-3 drafts for medium
+changers usually associated with tape libraries. By default this field
+is set to zero.
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+output the usage message then exit.
+.TP
+\fB\-H\fR, \fB\-\-hex\fR
+used together with the input file (\fB\-i\fR, \fB\-\-in\fR=\fIFN\fR) to indicate
+input contents is in hexadecimal format with no leading address (on each line),
+similar to one produced by \fBsg_read_attr \-HHH\fR output.
+.TP
+\fB\-i\fR, \fB\-\-in\fR=\fIFN\fR
+\fIFN\fR is treated as a file name (or '\-' for stdin) which contains attribute-value
+pairs one per line, ASCII hexadecimal or binary representing the payload of
+the WRITE ATTRIBUTE command. When this option is given then \fIattribute=value\fR pairs
+(if also given) are ignored.
+.br
+By default \fIFN\fR is assumed to contain a list of attribute-value pairs, one per line.
+Empty lines and lines starting from "#" are ignored.
+If the \fI\-\-hex\fR is given, \fIFN\fR is assumed to contain ASCII hexadecimal
+arranged as bytes which a space, tab or comma delimited. All characters from (and
+including) "#" to the end of line are ignored. If the \fI\-\-raw\fR option
+given then \fIFN\fR is assumed to contain binary data. When both \fI\-\-hex\fR and
+\fI\-\-raw\fR options are given, latter takes precedence.
+.TP
+\fB\-l\fR, \fB\-\-lvn\fR=\fILVN\fR
+where \fILVN\fR is placed in the "logical volume number" field of the cdb.
+The default value is zero which is required to be the logical volume number
+if the device only has one volume.
+.TP
+\fB\-p\fR, \fB\-\-pn\fR=\fIPN\fR
+where \fIPN\fR is placed in the "partition number" field of the cdb. If
+the \fIDEVICE\fR only has one partition then its partition number must be
+zero. The default value of \fIPN\fR is zero.
+.TP
+\fB\-r\fR, \fB\-\-raw\fR
+used together with the input file (\fB\-i\fR, \fB\-\-in\fR=\fIFN\fR) to indicate
+input format is binary, similar to one produced by \fBsg_read_attr \-\-raw\fR output.
+.TP
+\fB\-c\fR, \fB\-\-wtc\fR
+sets the WRITE THROUGH CACHE bit in the WRITE ATTRIBUTE cdb.
+This instructs the device server to return successful status only when
+the attributes have been synchronized with the medium auxiliary memory.
+By default the WTC bit is not set.
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+increase the level of verbosity, (i.e. debug output).
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+print the version string and then exit.
+.SS Attribute-value pair format
+An attribute-value pair comprised of the attribute identifier and attribute value,
+delimited by an equal sign \fB'='\fR or a colon \fB':'\fR.
+Attribute identifier can be specified as a number in decimal, octal (prefixed by '0')
+or hexadecimal (prefixed by '0x') representation, or with an acronym if the attribute provides one.
+Delimiter sign determines value representation: an equal sign denotes values in string or
+numerical format, or acronym, while a colon sign denotes a hex sequence comprised of bytes
+in hexadecimal form separated by a space or comma.
+.br
+String values can be used with attributes in ASCII or text format, while numbers and acronyms
+are suitable for binary attributes.
+Available acronyms can be listed by the \fB\-\-enumerate\fR options. Acronyms are case-insensitive.
+.br
+For the fixed-length binary attributes, value length must match attribute length exactly.
+Maximum binary attribute value in numerical representation is restricted by the unsigned long long
+type size on a given platform (8 bytes typically), while hexadecimal sequence can be of arbitrary length.
+.br
+Values of ASCII format attributes are left aligned padded with spaces to attribute length.
+.br
+Empty value (a delimiter followed by nothing) is used to delete a given attribute in device server.
+.br
+Attribute-value pairs in command line arguments containing spaces should be quoted or escaped.
+.SH NOTES
+Only tape systems seem to implement the SCSI WRITE ATTRIBUTE command. The vast
+majority of its definition is in the SPC standard so other device types could
+use it.
+.br
+Total buffer length for the attribute list in the SCSI WRITE ATTRIBUTE command payload is 1 MiB (1024 KiB).
+.SH EXAMPLES
+Set a tape barcode ASCII attribute specified by acronym and a string value:
+.PP
+\fB# sg_write_attr /dev/sg1 BarCode=BARCODE01\fR
+.PP
+Set a tape barcode ASCII attribute specified by hexadecimal identifier and a string value:
+.PP
+\fB# sg_write_attr /dev/sg1 0x806=BARCODE01\fR
+.PP
+Set a user label text attribute with string value containing spaces in quoted command line argument:
+.PP
+\fB# sg_write_attr /dev/sg1 "UserLabel=User label 1"\fR
+.PP
+Set a user label text attribute with hex sequence value:
+.PP
+\fB# sg_write_attr /dev/sg1 UserLabel:42,41,52,43,4F,44,45,30,32\fR
+.br
+or
+.br
+\fB# sg_write_attr /dev/sg1 "0x803:42 41 52 43 4F 44 45 30 32"\fR
+.PP
+Set a locale identifier attribute with values specified by acronyms or numbers:
+.PP
+\fB# sg_write_attr /dev/sg1 LocaleId=ascii\fR
+.br
+\fB# sg_write_attr /dev/sg1 LocaleId=utf-8\fR
+.br
+\fB# sg_write_attr /dev/sg1 LocaleId=0x80\fR
+.br
+\fB# sg_write_attr /dev/sg1 LocaleId:81\fR
+.br
+\fB# sg_write_attr /dev/sg1 0x805=iso-8859-9\fR
+.PP
+Set multiple attributes specified in command line arguments:
+.PP
+\fB# sg_write_attr /dev/sg1 BarCode=BARCODE01 "UserLabel=My User Label" LocaleId=iso-8859-1\fR
+.PP
+Set variable-length binary attribute with values in numerical or hex sequence formats:
+.PP
+\fB# sg_write_attr /dev/sg1 VCI=1\fR
+.br
+\fB# sg_write_attr /dev/sg1 VCI=65535\fR
+.br
+\fB# sg_write_attr /dev/sg1 VCI=0x012345\fR
+.br
+\fB# sg_write_attr /dev/sg1 VCI=0x0123456789abcdef\fR
+.br
+\fB# sg_write_attr /dev/sg1 VCI:01,23,45,67,89,ab,cd,ef,20,21,22,23,24,25,26,27,28,29,2a,2b,2c,2d,2e,2f\fR
+.PP
+Set fixed-length binary attribute using value in hex sequence format:
+.PP
+\fB# sg_write_attr /dev/sg1 "MediumGUID:63 38 66 36 62 39 32 32 2d 37 38 38 39 2d 31 31 65 64 2d 38 65 35 31 2d 66 37 36 65 62 32 63 39 38 38 64 31"\fR
+.PP
+Delete an attribute using empty value:
+.PP
+\fB# sg_write_attr /dev/sg1 BarCode=\fR
+.br
+or
+.br
+\fB# sg_write_attr /dev/sg1 BarCode:\fR
+.PP
+Delete multiple attributes:
+.PP
+\fB# sg_write_attr /dev/sg1 UserLabel= BarCode= 0x805=\fR
+.PP
+Set attributes specified in the text input file:
+.PP
+\fB# sg_write_attr \-\-in=attrs.txt /dev/sg1\fR
+.br
+Contents of the "attrs.txt" file:
+.br
+\fIAppVersion=1.02.15
+.br
+UserLabel=User Label 1
+.br
+LastWritten=251120221637
+.br
+Barcode=BARCODE02
+.br
+OwningHost=backup_server
+.br
+MediaPoolName=First Media Pool
+.br
+PartUserLabel=PART01
+.br
+LUatPart=1
+.br
+AppFmtVersion=MTF0125
+.br
+VCI=0x0123456789abcdef
+.br
+MediumGUID:62 64 61 36 62 30 35 34 2d 37 38 38 39 2d 31 31 65 64 2d 39 65 64 30 2d 62 37 31 30 63 32 62 63 30 34 30 39\fR
+.PP
+Set attribute list specified in the hexadecimal format input file:
+.PP
+\fB# sg_write_attr \-\-in=attrs_hex.txt \-\-hex /dev/sg1\fR
+.br
+Contents of the "attrs_hex.txt" file:
+.br
+\fI00 00 00 25 08 06 01 00  20 42 41 52 43 4f 44 45
+.br
+2d 30 32 20 20 20 20 20  20 20 20 20 20 20 20 20
+.br
+20 20 20 20 20 20 20 20  20\fR
+.PP
+Set attribute list specified in the raw binary input file:
+.PP
+\fB# sg_write_attr \-\-in=attrs_raw.bin \-\-raw /dev/sg1\fR
+.br
+Contents of the "attrs_raw.bin" file:
+.br
+\fI$ od -A x -t x1z -v attrs_raw.bin
+.br
+000000 00 00 00 25 08 06 01 00 20 42 41 52 43 4f 44 45  >...%.... BARCODE<
+.br
+000010 2d 30 32 20 20 20 20 20 20 20 20 20 20 20 20 20  >-02             <
+.br
+000020 20 20 20 20 20 20 20 20 20                       >         <
+.br
+000029\fR
+.SH EXIT STATUS
+The exit status of sg_write_attr is 0 when it is successful. Otherwise see
+the sg3_utils(8) man page.
+.SH AUTHORS
+Written by Douglas Gilbert and Boris Fox.
+.SH "REPORTING BUGS"
+Report bugs to <dgilbert at interlog dot com>.
+.SH COPYRIGHT
+Copyright \(co 2016\-2020 Douglas Gilbert, 2022 Boris Fox
+.br
+This software is distributed under a FreeBSD license. There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+.SH "SEE ALSO"
+.B sg_read_attrs(sg3_utils)

--- a/include/sg_lib.h
+++ b/include/sg_lib.h
@@ -605,6 +605,11 @@ bool sg_is_big_endian();
 bool sg_all_zeros(const uint8_t * bp, int b_len);
 bool sg_all_ffs(const uint8_t * bp, int b_len);
 
+/* Returns true if byte sequence contains only printable ASCII characters
+ * (locale independent), otherwise returns false.
+ *  If bp is NULL or b_len <= 0 returns false. */
+bool sg_all_printable(const uint8_t * bp, int b_len);
+
 /* Extract character sequence from ATA words as in the model string
  * in a IDENTIFY DEVICE response. Returns number of characters
  * written to 'ochars' before 0 character is found or 'num' words

--- a/lib/sg_lib.c
+++ b/lib/sg_lib.c
@@ -3020,6 +3020,18 @@ sg_all_ffs(const uint8_t * bp, int b_len)
     return true;
 }
 
+bool
+sg_all_printable(const uint8_t * bp, int b_len)
+{
+    if ((NULL == bp) || (b_len <= 0))
+        return false;
+    for (--b_len; b_len >= 0; --b_len) {
+        if (!my_isprint(bp[b_len]))
+            return false;
+    }
+    return true;
+}
+
 static uint16_t
 swapb_uint16(uint16_t u)
 {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,8 +9,8 @@ bin_PROGRAMS = \
 	sg_sanitize sg_sat_identify sg_sat_phy_event sg_sat_read_gplog \
 	sg_sat_set_features sg_seek sg_senddiag sg_ses sg_ses_microcode \
 	sg_start sg_stpg sg_stream_ctl sg_sync sg_timestamp sg_turs sg_unmap \
-	sg_verify sg_vpd sg_wr_mode sg_write_buffer sg_write_long \
-	sg_write_same sg_write_verify sg_write_x sg_zone
+	sg_verify sg_vpd sg_wr_mode sg_write_attr sg_write_buffer \
+	sg_write_long sg_write_same sg_write_verify sg_write_x sg_zone
 sg_scan_SOURCES =
 
 
@@ -186,6 +186,8 @@ sg_vpd_SOURCES = sg_vpd.c sg_vpd_vendor.c
 sg_vpd_LDADD = ../lib/libsgutils2.la
 
 sg_wr_mode_LDADD = ../lib/libsgutils2.la
+
+sg_write_attr_LDADD = ../lib/libsgutils2.la
 
 sg_write_buffer_LDADD = ../lib/libsgutils2.la
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -107,10 +107,11 @@ bin_PROGRAMS = sg_bg_ctl$(EXEEXT) sg_compare_and_write$(EXEEXT) \
 	sg_ses_microcode$(EXEEXT) sg_start$(EXEEXT) sg_stpg$(EXEEXT) \
 	sg_stream_ctl$(EXEEXT) sg_sync$(EXEEXT) sg_timestamp$(EXEEXT) \
 	sg_turs$(EXEEXT) sg_unmap$(EXEEXT) sg_verify$(EXEEXT) \
-	sg_vpd$(EXEEXT) sg_wr_mode$(EXEEXT) sg_write_buffer$(EXEEXT) \
-	sg_write_long$(EXEEXT) sg_write_same$(EXEEXT) \
-	sg_write_verify$(EXEEXT) sg_write_x$(EXEEXT) sg_zone$(EXEEXT) \
-	$(am__EXEEXT_1) $(am__EXEEXT_2) $(am__EXEEXT_3)
+	sg_vpd$(EXEEXT) sg_wr_mode$(EXEEXT) sg_write_attr$(EXEEXT) \
+	sg_write_buffer$(EXEEXT) sg_write_long$(EXEEXT) \
+	sg_write_same$(EXEEXT) sg_write_verify$(EXEEXT) \
+	sg_write_x$(EXEEXT) sg_zone$(EXEEXT) $(am__EXEEXT_1) \
+	$(am__EXEEXT_2) $(am__EXEEXT_3)
 @OS_LINUX_TRUE@am__append_1 = \
 @OS_LINUX_TRUE@	sg_copy_results sg_dd sg_emc_trespass sg_map sg_map26 sg_rbuf \
 @OS_LINUX_TRUE@	sg_read sg_reset sg_scan sg_test_rwbuf sg_xcopy sginfo sgm_dd sgp_dd
@@ -330,6 +331,9 @@ sg_vpd_DEPENDENCIES = ../lib/libsgutils2.la
 sg_wr_mode_SOURCES = sg_wr_mode.c
 sg_wr_mode_OBJECTS = sg_wr_mode.$(OBJEXT)
 sg_wr_mode_DEPENDENCIES = ../lib/libsgutils2.la
+sg_write_attr_SOURCES = sg_write_attr.c
+sg_write_attr_OBJECTS = sg_write_attr.$(OBJEXT)
+sg_write_attr_DEPENDENCIES = ../lib/libsgutils2.la
 sg_write_buffer_SOURCES = sg_write_buffer.c
 sg_write_buffer_OBJECTS = sg_write_buffer.$(OBJEXT)
 sg_write_buffer_DEPENDENCIES = ../lib/libsgutils2.la
@@ -410,11 +414,12 @@ am__depfiles_remade = ./$(DEPDIR)/sg_bg_ctl.Po \
 	./$(DEPDIR)/sg_turs.Po ./$(DEPDIR)/sg_unmap.Po \
 	./$(DEPDIR)/sg_verify.Po ./$(DEPDIR)/sg_vpd.Po \
 	./$(DEPDIR)/sg_vpd_vendor.Po ./$(DEPDIR)/sg_wr_mode.Po \
-	./$(DEPDIR)/sg_write_buffer.Po ./$(DEPDIR)/sg_write_long.Po \
-	./$(DEPDIR)/sg_write_same.Po ./$(DEPDIR)/sg_write_verify.Po \
-	./$(DEPDIR)/sg_write_x.Po ./$(DEPDIR)/sg_xcopy.Po \
-	./$(DEPDIR)/sg_zone.Po ./$(DEPDIR)/sginfo.Po \
-	./$(DEPDIR)/sgm_dd.Po ./$(DEPDIR)/sgp_dd.Po
+	./$(DEPDIR)/sg_write_attr.Po ./$(DEPDIR)/sg_write_buffer.Po \
+	./$(DEPDIR)/sg_write_long.Po ./$(DEPDIR)/sg_write_same.Po \
+	./$(DEPDIR)/sg_write_verify.Po ./$(DEPDIR)/sg_write_x.Po \
+	./$(DEPDIR)/sg_xcopy.Po ./$(DEPDIR)/sg_zone.Po \
+	./$(DEPDIR)/sginfo.Po ./$(DEPDIR)/sgm_dd.Po \
+	./$(DEPDIR)/sgp_dd.Po
 am__mv = mv -f
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
@@ -448,9 +453,10 @@ SOURCES = sg_bg_ctl.c sg_compare_and_write.c sg_copy_results.c sg_dd.c \
 	$(sg_scan_SOURCES) sg_seek.c sg_senddiag.c sg_ses.c \
 	sg_ses_microcode.c sg_start.c sg_stpg.c sg_stream_ctl.c \
 	sg_sync.c sg_test_rwbuf.c sg_timestamp.c sg_turs.c sg_unmap.c \
-	sg_verify.c $(sg_vpd_SOURCES) sg_wr_mode.c sg_write_buffer.c \
-	sg_write_long.c sg_write_same.c sg_write_verify.c sg_write_x.c \
-	sg_xcopy.c sg_zone.c sginfo.c sgm_dd.c sgp_dd.c
+	sg_verify.c $(sg_vpd_SOURCES) sg_wr_mode.c sg_write_attr.c \
+	sg_write_buffer.c sg_write_long.c sg_write_same.c \
+	sg_write_verify.c sg_write_x.c sg_xcopy.c sg_zone.c sginfo.c \
+	sgm_dd.c sgp_dd.c
 DIST_SOURCES = sg_bg_ctl.c sg_compare_and_write.c sg_copy_results.c \
 	sg_dd.c sg_decode_sense.c sg_emc_trespass.c sg_format.c \
 	sg_get_config.c sg_get_elem_status.c sg_get_lba_status.c \
@@ -465,9 +471,10 @@ DIST_SOURCES = sg_bg_ctl.c sg_compare_and_write.c sg_copy_results.c \
 	$(am__sg_scan_SOURCES_DIST) sg_seek.c sg_senddiag.c sg_ses.c \
 	sg_ses_microcode.c sg_start.c sg_stpg.c sg_stream_ctl.c \
 	sg_sync.c sg_test_rwbuf.c sg_timestamp.c sg_turs.c sg_unmap.c \
-	sg_verify.c $(sg_vpd_SOURCES) sg_wr_mode.c sg_write_buffer.c \
-	sg_write_long.c sg_write_same.c sg_write_verify.c sg_write_x.c \
-	sg_xcopy.c sg_zone.c sginfo.c sgm_dd.c sgp_dd.c
+	sg_verify.c $(sg_vpd_SOURCES) sg_wr_mode.c sg_write_attr.c \
+	sg_write_buffer.c sg_write_long.c sg_write_same.c \
+	sg_write_verify.c sg_write_x.c sg_xcopy.c sg_zone.c sginfo.c \
+	sgm_dd.c sgp_dd.c
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -700,6 +707,7 @@ sg_verify_LDADD = ../lib/libsgutils2.la
 sg_vpd_SOURCES = sg_vpd.c sg_vpd_vendor.c
 sg_vpd_LDADD = ../lib/libsgutils2.la
 sg_wr_mode_LDADD = ../lib/libsgutils2.la
+sg_write_attr_LDADD = ../lib/libsgutils2.la
 sg_write_buffer_LDADD = ../lib/libsgutils2.la
 sg_write_long_LDADD = ../lib/libsgutils2.la
 sg_write_same_LDADD = ../lib/libsgutils2.la
@@ -1030,6 +1038,10 @@ sg_wr_mode$(EXEEXT): $(sg_wr_mode_OBJECTS) $(sg_wr_mode_DEPENDENCIES) $(EXTRA_sg
 	@rm -f sg_wr_mode$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(sg_wr_mode_OBJECTS) $(sg_wr_mode_LDADD) $(LIBS)
 
+sg_write_attr$(EXEEXT): $(sg_write_attr_OBJECTS) $(sg_write_attr_DEPENDENCIES) $(EXTRA_sg_write_attr_DEPENDENCIES) 
+	@rm -f sg_write_attr$(EXEEXT)
+	$(AM_V_CCLD)$(LINK) $(sg_write_attr_OBJECTS) $(sg_write_attr_LDADD) $(LIBS)
+
 sg_write_buffer$(EXEEXT): $(sg_write_buffer_OBJECTS) $(sg_write_buffer_DEPENDENCIES) $(EXTRA_sg_write_buffer_DEPENDENCIES) 
 	@rm -f sg_write_buffer$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(sg_write_buffer_OBJECTS) $(sg_write_buffer_LDADD) $(LIBS)
@@ -1139,6 +1151,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/sg_vpd.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/sg_vpd_vendor.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/sg_wr_mode.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/sg_write_attr.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/sg_write_buffer.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/sg_write_long.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/sg_write_same.Po@am__quote@ # am--include-marker
@@ -1373,6 +1386,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/sg_vpd.Po
 	-rm -f ./$(DEPDIR)/sg_vpd_vendor.Po
 	-rm -f ./$(DEPDIR)/sg_wr_mode.Po
+	-rm -f ./$(DEPDIR)/sg_write_attr.Po
 	-rm -f ./$(DEPDIR)/sg_write_buffer.Po
 	-rm -f ./$(DEPDIR)/sg_write_long.Po
 	-rm -f ./$(DEPDIR)/sg_write_same.Po
@@ -1491,6 +1505,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/sg_vpd.Po
 	-rm -f ./$(DEPDIR)/sg_vpd_vendor.Po
 	-rm -f ./$(DEPDIR)/sg_wr_mode.Po
+	-rm -f ./$(DEPDIR)/sg_write_attr.Po
 	-rm -f ./$(DEPDIR)/sg_write_buffer.Po
 	-rm -f ./$(DEPDIR)/sg_write_long.Po
 	-rm -f ./$(DEPDIR)/sg_write_same.Po

--- a/src/sg_read_attr.c
+++ b/src/sg_read_attr.c
@@ -180,7 +180,7 @@ static struct attr_name_info_t attr_name_arr[] = {
     {0x808, "Media pool", RA_FMT_TEXT, 160, 0},
     {0x809, "Partition user text label", RA_FMT_ASCII, 16, 0},
     {0x80a, "Load/unload at partition", RA_FMT_BINARY, 1, 0},
-    {0x80a, "Application format version", RA_FMT_ASCII, 16, 0},
+    {0x80b, "Application format version", RA_FMT_ASCII, 16, 0},
     {0x80c, "Volume coherency information", RA_FMT_BINARY, -1, 1},
      /* SSC-5 */
     {0x820, "Medium globally unique identifier", RA_FMT_BINARY, 36, 1},

--- a/src/sg_write_attr.c
+++ b/src/sg_write_attr.c
@@ -1,0 +1,1018 @@
+/*
+ * Copyright (c) 2016-2019 Douglas Gilbert.
+ * Copyright (c) 2022 Boris Fox.
+ * All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the BSD_LICENSE file.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <errno.h>
+#include <ctype.h>
+#include <getopt.h>
+#define __STDC_FORMAT_MACROS 1
+#include <inttypes.h>
+#include <assert.h>
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "sg_lib.h"
+#include "sg_pt.h"
+#include "sg_cmds_basic.h"
+#include "sg_unaligned.h"
+#include "sg_pr2serr.h"
+
+/* A utility program originally written for the Linux OS SCSI subsystem.
+ *
+ * This program issues the SCSI WRITE ATTRIBUTE command to the given SCSI device
+ * and decodes the response. Based on spc5r19.pdf
+ */
+
+static const char * version_str = "1.00 20221125";
+
+#define MAX_ATTR_VALUE_LEN SG_LIB_UNBOUNDED_16BIT
+#define MAX_ATTR_BUFF_LEN (1024 * 1024)
+
+#define ATTR_LIST_ITEM_HEADER_LEN (2+1+2)
+#define ATTR_LIST_HEADER_LEN (4)
+
+#define SG_WRITE_ATTRIBUTE_CMD 0x8d
+#define SG_WRITE_ATTRIBUTE_CMDLEN 16
+
+#define RA_FMT_BINARY 0x0
+#define RA_FMT_ASCII 0x1
+#define RA_FMT_TEXT 0x2         /* takes into account locale */
+#define RA_FMT_RES 0x3          /* reserved */
+
+#define SENSE_BUFF_LEN 64       /* Arbitrary, could be larger */
+#define DEF_PT_TIMEOUT  60      /* 60 seconds */
+
+struct opts_t {
+    bool wtc;
+    bool enumerate;
+    bool do_raw;
+    bool do_hex;
+    bool verbose_given;
+    bool version_given;
+    int elem_addr;
+    int lvn;
+    int pn;
+    int verbose;
+};
+
+struct acron_nv_t {
+    uint8_t val;
+    const char * acronym;
+    const char * name;
+};
+
+struct attr_name_info_t {
+    int id;
+    const char * acronym; /* attribute acronym name */
+    const char * name;  /* tab ('\t') suggest line break */
+    int format;         /* RA_FMT_BINARY and friends, -1 --> unknown */
+    int len;            /* -1 --> not fixed (variable) */
+    int process;        /* 0 --> print decimal if binary, 1 --> print hex,
+                         * 2 --> further processing */
+    const struct acron_nv_t * val_acronyms; /* attribute value acronyms */
+};
+
+struct attr_value_pair_t {
+    int     id;
+    const char * name;
+    int     format;
+    int     len;		/* -1 is variable */
+    int     val_len;
+    uint8_t value[MAX_ATTR_VALUE_LEN];
+};
+
+static struct option long_options[] = {
+    {"wtc", no_argument, 0, 'c'},
+    {"enumerate", no_argument, 0, 'e'},
+    {"element", required_argument, 0, 'E'},   /* SMC-3 element address */
+    {"help", no_argument, 0, 'h'},
+    {"hex", no_argument, 0, 'H'},
+    {"in", required_argument, 0, 'i'},
+    {"lvn", required_argument, 0, 'l'},
+    {"partition", required_argument, 0, 'p'},
+    {"raw", no_argument, 0, 'r'},
+    {"verbose", no_argument, 0, 'v'},
+    {"version", no_argument, 0, 'V'},
+    {0, 0, 0, 0},   /* sentinel */
+};
+
+/* Attribute value acronyms currently implemented for single-byte values only */
+static struct acron_nv_t tli_acron_arr[] = {
+/* Text localization identifier. Acronyms must match charset names supported by iconv library */
+        { 0x00, "ascii", "No code specified (ASCII)" },
+        { 0x01, "iso-8859-1", "ISO/IEC 8859-1 (Europe, Latin America)" },
+        { 0x02, "iso-8859-2", "ISO/IEC 8859-2 (Eastern Europe)" },
+        { 0x03, "iso-8859-3", "ISO/IEC 8859-3 (SE Europe/miscellaneous)" },
+        { 0x04, "iso-8859-4", "ISO/IEC 8859-4 (Scandinavia/Baltic)" },
+        { 0x05, "iso-8859-5", "ISO/IEC 8859-5 (Cyrillic)" },
+        { 0x06, "iso-8859-6", "ISO/IEC 8859-6 (Arabic)" },
+        { 0x07, "iso-8859-7", "ISO/IEC 8859-7 (Greek)" },
+        { 0x08, "iso-8859-8", "ISO/IEC 8859-8 (Hebrew)" },
+        { 0x09, "iso-8859-9", "ISO/IEC 8859-9 (Latin 5)" },
+        { 0x0A, "iso-8859-10", "ISO/IEC 8859-10 (Latin 6)" },
+        /* 0Bh to 7Fh Reserved */
+        { 0x80, "ucs-2be", "ISO/IEC 10646-1 (UCS-2BE)" },
+        { 0x81, "utf-8", "ISO/IEC 10646-1 (UTF-8)" },
+        /* 82h to FFh Reserved */
+        { -1, NULL, NULL }
+};
+
+/* Only Host type attributes are writable in most devices */
+static struct attr_name_info_t attr_name_arr[] = {
+/* Device type attributes */
+    {0x0, NULL, "Remaining capacity in partition [MiB]", RA_FMT_BINARY, 8, 0, NULL},
+    {0x1, NULL, "Maximum capacity in partition [MiB]", RA_FMT_BINARY, 8, 0, NULL},
+    {0x2, NULL, "TapeAlert flags", RA_FMT_BINARY, 8, 0, NULL},   /* SSC-4 */
+    {0x3, NULL, "Load count", RA_FMT_BINARY, 8, 0, NULL},
+    {0x4, NULL, "MAM space remaining [B]", RA_FMT_BINARY, 8, 0, NULL},
+    {0x5, NULL, "Assigning organization", RA_FMT_ASCII, 8, 0, NULL}, /* SSC-4 */
+    {0x6, NULL, "Format density code", RA_FMT_BINARY, 1, 1, NULL},    /* SSC-4 */
+    {0x7, NULL, "Initialization count", RA_FMT_BINARY, 2, 0, NULL},
+    {0x8, NULL, "Volume identifier", RA_FMT_ASCII, 32, 0, NULL},
+    {0x9, NULL, "Volume change reference", RA_FMT_BINARY, -1, 1, NULL}, /* SSC-4 */
+    {0x20a, NULL, "Density vendor/serial number at last load", RA_FMT_ASCII, 40, 0, NULL},
+    {0x20b, NULL, "Density vendor/serial number at load-1", RA_FMT_ASCII, 40, 0, NULL},
+    {0x20c, NULL, "Density vendor/serial number at load-2", RA_FMT_ASCII, 40, 0, NULL},
+    {0x20d, NULL, "Density vendor/serial number at load-3", RA_FMT_ASCII, 40, 0, NULL},
+    {0x220, NULL, "Total MiB written in medium life", RA_FMT_BINARY, 8, 0, NULL},
+    {0x221, NULL, "Total MiB read in medium life", RA_FMT_BINARY, 8, 0, NULL},
+    {0x222, NULL, "Total MiB written in current/last load", RA_FMT_BINARY, 8, 0, NULL},
+    {0x223, NULL, "Total MiB read in current/last load", RA_FMT_BINARY, 8, 0, NULL},
+    {0x224, NULL, "Logical position of first encrypted block", RA_FMT_BINARY, 8, 2, NULL},
+    {0x225, NULL, "Logical position of first unencrypted block\tafter first "
+     "encrypted block", RA_FMT_BINARY, 8, 2, NULL},
+    {0x340, NULL, "Medium usage history", RA_FMT_BINARY, 90, 2, NULL},
+    {0x341, NULL, "Partition usage history", RA_FMT_BINARY, 60, 2, NULL},
+
+/* Medium type attributes */
+    {0x400, NULL, "Medium manufacturer", RA_FMT_ASCII, 8, 0, NULL},
+    {0x401, NULL, "Medium serial number", RA_FMT_ASCII, 32, 0, NULL},
+    {0x402, NULL, "Medium length [m]", RA_FMT_BINARY, 4, 0, NULL},      /* SSC-4 */
+    {0x403, NULL, "Medium width [0.1 mm]", RA_FMT_BINARY, 4, 0, NULL},  /* SSC-4 */
+    {0x404, NULL, "Assigning organization", RA_FMT_ASCII, 8, 0, NULL},  /* SSC-4 */
+    {0x405, NULL, "Medium density code", RA_FMT_BINARY, 1, 1, NULL},    /* SSC-4 */
+    {0x406, NULL, "Medium manufacture date", RA_FMT_ASCII, 8, 0, NULL},
+    {0x407, NULL, "MAM capacity [B]", RA_FMT_BINARY, 8, 0, NULL},
+    {0x408, NULL, "Medium type", RA_FMT_BINARY, 1, 1, NULL},
+    {0x409, NULL, "Medium type information", RA_FMT_BINARY, 2, 1, NULL},
+    {0x40a, NULL, "Numeric medium serial number", -1, -1, 1, NULL},
+
+/* Host type attributes */
+    {0x800, "AppVendor", "Application vendor", RA_FMT_ASCII, 8, 0, NULL},
+    {0x801, "AppName", "Application name", RA_FMT_ASCII, 32, 0, NULL},
+    {0x802, "AppVersion", "Application version", RA_FMT_ASCII, 8, 0, NULL},
+    {0x803, "UserLabel", "User medium text label", RA_FMT_TEXT, 160, 0, NULL},
+    {0x804, "LastWritten", "Date and time last written", RA_FMT_ASCII, 12, 0, NULL},
+    {0x805, "LocaleId", "Text localization identifier", RA_FMT_BINARY, 1, 0, tli_acron_arr},
+    {0x806, "Barcode", "Barcode", RA_FMT_ASCII, 32, 0, NULL},
+    {0x807, "OwningHost", "Owning host textual name", RA_FMT_TEXT, 80, 0, NULL},
+    {0x808, "MediaPoolName", "Media pool name", RA_FMT_TEXT, 160, 0, NULL},
+    {0x809, "PartUserLabel", "Partition user text label", RA_FMT_ASCII, 16, 0, NULL},
+    {0x80a, "LUatPart", "Load/unload at partition", RA_FMT_BINARY, 1, 0, NULL},
+    {0x80b, "AppFmtVersion", "Application format version", RA_FMT_ASCII, 16, 0, NULL},
+    {0x80c, "VCI", "Volume coherency information", RA_FMT_BINARY, -1, 1, NULL},
+     /* SSC-5 */
+    {0x820, "MediumGUID", "Medium globally unique identifier", RA_FMT_BINARY, 36, 1, NULL},
+    {0x821, "MediaPoolGUID", "Media pool globally unique identifier", RA_FMT_BINARY, 36, 1, NULL},
+
+    {-1, NULL, NULL, -1, -1, 0, NULL},
+};
+
+static void
+usage()
+{
+    pr2serr("Usage: sg_write_attr [--wtc] [--element=EA] [--enumerate]\n"
+            "                     [--help] [--hex] [--in=FN] [--lvn=LVN]\n"
+            "                     [--partition=PN] [--raw]\n"
+            "                     [--verbose] [--version]\n"
+            "                     DEVICE [attr=value [attr=value ...]]\n");
+    pr2serr("  where:\n"
+            "    --wtc|-c           set WRITE THROUGH CACHE bit in cdn (def: clear)\n"
+            "    --enumerate|-e     enumerate known attributes and service "
+            "actions\n"
+            "    --element=EA|-E EA    EA is placed in 'element address' "
+            "field in\n"
+            "                          cdb [SMC-3] (def: 0)\n"
+            "    --help|-h          print out usage message\n"
+            "    --hex|-H           input file contains attribute list in hex format\n"
+            "    --in=FN|-i FN      FN is a filename containing attribute-value "
+            "pairs\n"
+            "                       or attribute list in binary/hex format\n"
+            "                       if used with --raw or --hex\n"
+            "    --lvn=LVN|-l LVN        logical volume number (LVN) (def:0)\n"
+            "    --partition=PN|-p PN    partition number (PN) (def:0)\n"
+            "    --raw|-r           input file contains binary attribute list\n"
+            "    --verbose|-v       increase verbosity\n"
+            "    --version|-V       print version string and exit\n\n"
+            "Performs a SCSI WRITE ATTRIBUTE command. Even though it is "
+            "defined in\nSPC-3 and later it is typically used on tape "
+            "systems.\n");
+}
+
+/* Invokes a SCSI WRITE ATTRIBUTE command (SPC+SMC).  Return of 0 -> success,
+ * various SG_LIB_CAT_* positive values or -1 -> other errors */
+static int
+sg_ll_write_attr(const int sg_fd, const void * data, const int data_len, const bool noisy,
+                 const struct opts_t * op)
+{
+    int ret, res, sense_cat;
+    uint8_t ra_cdb[SG_WRITE_ATTRIBUTE_CMDLEN] =
+          {SG_WRITE_ATTRIBUTE_CMD, 0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0,
+           0, 0, 0, 0};
+    uint8_t sense_b[SENSE_BUFF_LEN];
+    struct sg_pt_base * ptvp;
+
+    if (op->wtc)
+        ra_cdb[1] |= 0x1;
+    if (op->elem_addr)
+        sg_put_unaligned_be16(op->elem_addr, ra_cdb + 2);
+    if (op->lvn)
+        ra_cdb[5] = 0xff & op->lvn;
+    if (op->pn)
+        ra_cdb[7] = 0xff & op->pn;
+    sg_put_unaligned_be32((uint32_t)data_len, ra_cdb + 10);
+    if (op->verbose) {
+        char b[128];
+
+        pr2serr("Write attribute cdb: %s\n",
+                sg_get_command_str(ra_cdb, SG_WRITE_ATTRIBUTE_CMDLEN, false,
+                                   sizeof(b), b));
+        pr2serr("Write attribute list:\n");
+        hex2stderr(data, data_len, 0);
+    }
+
+    ptvp = construct_scsi_pt_obj();
+    if (NULL == ptvp) {
+        pr2serr("%s: out of memory\n", __func__);
+        return -1;
+    }
+    set_scsi_pt_cdb(ptvp, ra_cdb, sizeof(ra_cdb));
+    set_scsi_pt_sense(ptvp, sense_b, sizeof(sense_b));
+    set_scsi_pt_data_out(ptvp, data, data_len);
+    res = do_scsi_pt(ptvp, sg_fd, DEF_PT_TIMEOUT, op->verbose);
+    ret = sg_cmds_process_resp(ptvp, "write attribute", res, noisy,
+                               op->verbose, &sense_cat);
+    if (-1 == ret)
+        ret = sg_convert_errno(get_scsi_pt_os_err(ptvp));
+    else if (-2 == ret) {
+        switch (sense_cat) {
+        case SG_LIB_CAT_RECOVERED:
+        case SG_LIB_CAT_NO_SENSE:
+            ret = 0;
+            break;
+        default:
+            ret = sense_cat;
+            break;
+        }
+    } else
+        ret = 0;
+    destruct_scsi_pt_obj(ptvp);
+    return ret;
+}
+
+static const struct attr_name_info_t *
+find_attr_by_acronym(const char * cp)
+{
+    int k;
+    const struct attr_name_info_t * anip;
+    const char * mp;
+
+    for (anip = attr_name_arr; anip->name ; ++anip) {
+        if (NULL == anip->acronym)
+            continue;
+        for (mp = cp, k = 0; *mp; ++mp, ++k) {
+            if (tolower(*mp) != tolower(anip->acronym[k]))
+                break;
+        }
+        if ((0 == *mp) && (0 == anip->acronym[k]))
+            return anip;
+    }
+    return NULL;  /* not found */
+}
+
+static const struct attr_name_info_t *
+find_attr_by_id(const char * cp)
+{
+    unsigned long id;
+    const struct attr_name_info_t * anip;
+    char *endptr;
+
+    /* Try to decode as hexadecimal numerical id, validate against the supported list */
+    errno = 0;
+    id = strtoul(cp, &endptr, 0);
+    if (0 == errno && '\0' == *endptr) {
+        for (anip = attr_name_arr; anip->name ; ++anip) {
+            if (id == (unsigned long)anip->id)
+                return anip;
+        }
+    }
+    return NULL;  /* not found */
+}
+
+static const struct acron_nv_t *
+find_value_by_acronym(const char * cp, const struct acron_nv_t * anvp)
+{
+    int k;
+    const char * mp;
+
+    if (NULL == anvp)
+        return NULL;
+    for (; anvp->name; ++anvp) {
+        if (NULL == anvp->acronym)
+            continue;
+        for (mp = cp, k = 0; *mp; ++mp, ++k) {
+            if (tolower(*mp) != tolower(anvp->acronym[k]))
+                break;
+        }
+        if ((0 == *mp) && (0 == anvp->acronym[k]))
+            return anvp;
+    }
+    return NULL;  /* not found */
+}
+
+const char * a_format[] = {
+    "binary",
+    "ascii",
+    "text",
+    "format[0x3]",
+};
+
+static void
+enum_attributes(void)
+{
+    const struct attr_name_info_t * anip;
+    const struct acron_nv_t * anvp;
+    const char * cp;
+    char b[32];
+    int has_acronyms = 0;
+
+    printf("Attribute ID\tLength\tFormat\tAcronym\t\tName\n");
+    printf("-------------------------------------------------------------\n");
+    for (anip = attr_name_arr; anip->name ; ++anip) {
+        if (anip->format < 0)
+            snprintf(b, sizeof(b), "unknown");
+        else
+            snprintf(b, sizeof(b), "%s", a_format[0x3 & anip->format]);
+        printf("  0x%04x:\t%d\t%s\t%-13s\t", anip->id, anip->len, b,
+               anip->acronym != NULL ? anip->acronym : "");
+        cp = strchr(anip->name, '\t');
+        if (cp) {
+            printf("%.*s\n", (int)(cp - anip->name), anip->name);
+            printf("\t\t\t\t\t\t%s\n", cp + 1);
+        } else
+            printf("%s\n", anip->name);
+        if (anip->val_acronyms)
+            has_acronyms = 1;
+    }
+
+    if (has_acronyms) {
+        printf("\nAttribute Value acronyms\n");
+        printf("    Value\tAcronym\t\tName\n");
+        printf("-------------------------------------------------------------\n");
+        for (anip = attr_name_arr; anip->name ; ++anip) {
+            if (anip->val_acronyms) {
+                printf("0x%04x %s:\n", anip->id, anip->name);
+                for (anvp = anip->val_acronyms; anvp->name; ++anvp)
+                    printf("    0x%02x:\t%-13s\t%s\n", anvp->val, anvp->acronym, anvp->name);
+            }
+        }
+    }
+}
+
+/* Read hex numbers from command or file line (comma separated list).
+ * Can also be (single) space separated list but needs to be quoted on the
+ * command line. Returns 0 if ok, or 1 if error. */
+static int
+parse_hex_string(const char * inp, uint8_t * arr, int * arr_len, int max_arr_len)
+{
+	int in_len, k;
+	unsigned int h;
+	const char * lcp;
+	char * cp;
+	char * c2p;
+
+	if ((NULL == inp) || (NULL == arr) || (NULL == arr_len))
+		return SG_LIB_LOGIC_ERROR;
+	lcp = inp;
+	in_len = strlen(inp);
+	if (0 == in_len) {
+		*arr_len = 0;
+		return 0;
+	}
+    /* hex string on command line */
+	k = strspn(inp, "0123456789aAbBcCdDeEfF, ");
+	if (in_len != k) {
+		pr2serr("%s: error at pos %d\n", __func__, k + 1);
+		return SG_LIB_SYNTAX_ERROR;
+	}
+	for (k = 0; k < max_arr_len; ++k) {
+		if (1 == sscanf(lcp, "%x", &h)) {
+			if (h > 0xff) {
+				pr2serr("%s: hex number larger than 0xff at pos %d\n",
+				        __func__, (int)(lcp - inp + 1));
+				return SG_LIB_SYNTAX_ERROR;
+			}
+			arr[k] = h;
+			cp = (char *)strchr(lcp, ',');
+			c2p = (char *)strchr(lcp, ' ');
+			if (NULL == cp)
+				cp = c2p;
+			if (NULL == cp)
+				break;
+			if (c2p && (c2p < cp))
+				cp = c2p;
+			lcp = cp + 1;
+		} else {
+			pr2serr("%s: error at pos %d\n", __func__,
+			        (int)(lcp - inp + 1));
+			return SG_LIB_SYNTAX_ERROR;
+		}
+	}
+	*arr_len = k + 1;
+	if (k == max_arr_len) {
+		pr2serr("%s: array length exceeded\n", __func__);
+		return SG_LIB_LBA_OUT_OF_RANGE;
+	}
+	return 0;
+}
+
+static int
+sg_nbytes(unsigned long long x)
+{
+    int n = 0;
+
+    do {
+        x >>= 8;
+        n++;
+    } while(x);
+
+    return n;
+}
+
+static void
+sg_put_unaligned_be(void *dst, const void *src, const size_t len)
+{
+    const uint8_t *psrc = src;
+    uint8_t *pdst = dst;
+
+    switch (len) {
+        case 0:
+            break;
+        case sizeof(uint8_t):
+            *pdst = *psrc;
+            break;
+        case sizeof(uint16_t):
+            sg_put_unaligned_be16(*((uint16_t *)src), dst);
+            break;
+        case sizeof(uint32_t):
+            sg_put_unaligned_be32(*((uint32_t *)src), dst);
+            break;
+        case sizeof(uint64_t):
+            sg_put_unaligned_be64(*((uint64_t *)src), dst);
+            break;
+        default:
+#if defined(__LITTLE_ENDIAN__) || (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+            pdst += len-1;
+            for (size_t i = 0; i < len; i++)
+                *pdst-- = *psrc++;
+#elif defined(__BIG_ENDIAN__) || (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+            memcpy(dst, src, len);
+#endif
+    }
+}
+
+/* Parse attribute value according to format */
+static int
+parse_attr_value(const char * attr_value, const bool do_hex, const int attr_no,
+                 struct attr_value_pair_t * avp, const struct attr_name_info_t * anip)
+{
+    const char * format = anip->format == RA_FMT_BINARY ? "Binary" : (RA_FMT_ASCII ? "ASCII" : (RA_FMT_TEXT ? "Text" : "Reserved"));
+    const struct acron_nv_t * anvp;
+    unsigned long l, vl;
+    unsigned long long ull;
+    char *endptr;
+    int ret;
+
+    if (do_hex) {
+        ret = parse_hex_string(attr_value, avp->value, &avp->val_len, sizeof avp->value);
+        if (0 != ret)
+            return ret;
+    } else {
+        switch (anip->format) {
+            case RA_FMT_BINARY:
+                /* try numerical format first (up to the longest type size available), then acronym for 1-byte attributes */
+                errno = 0;
+                ull = strtoull(attr_value, &endptr, 0);
+                if (0 == errno && '\0' == *endptr) {
+                    l = sizeof(ull);
+                    vl = sg_nbytes(ull);
+                    if (vl > sizeof avp->value) {
+                        pr2serr("%s: %s attribute id 0x%04x in attribute-value pair #%d value too long (%lu > %zu bytes max)\n",
+                                __func__, format, anip->id, attr_no,
+                                vl, sizeof(avp->value));
+                        return SG_LIB_LBA_OUT_OF_RANGE;
+                    }
+                    if (-1 != avp->len) {
+                        if (l < (unsigned long) avp->len) {
+                            pr2serr("%s: %s attribute id 0x%04x in attribute-value pair #%d numerical value length too small (%lu < %d bytes), use hex sequence format\n",
+                                    __func__, format, anip->id, attr_no,
+                                    l, avp->len);
+                            return SG_LIB_SYNTAX_ERROR;
+                        }
+                        if (vl > (unsigned long) avp->len) {
+                            pr2serr("%s: %s attribute id 0x%04x in attribute-value pair #%d numerical value length too large (%lu > %d bytes)\n",
+                                    __func__, format, anip->id, attr_no,
+                                    vl, avp->len);
+                            return SG_LIB_SYNTAX_ERROR;
+                        }
+                        l = avp->len;
+                    } else
+                        l = vl;
+                    sg_put_unaligned_be(avp->value, &ull, l);
+                    avp->val_len = l;
+                } else {
+                    anvp = find_value_by_acronym(attr_value, anip->val_acronyms);
+                    if (NULL == anvp) {
+                        pr2serr("%s: %s attribute id 0x%04x in attribute-value pair #%d value '%s' is neither valid number nor acronym\n",
+                                __func__, format, anip->id, attr_no, attr_value);
+                        return SG_LIB_SYNTAX_ERROR;
+                    } else {
+                        /* length check will be enforced below */
+                        avp->value[0] = anvp->val;
+                        avp->val_len = sizeof(anvp->val);
+                    }
+                }
+
+                break;
+            case RA_FMT_ASCII:
+            case RA_FMT_TEXT:
+                /* ASCII or text string */
+                l = strlen(attr_value);
+                if (l > sizeof avp->value) {
+                    pr2serr("%s: %s attribute id 0x%04x in attribute-value pair #%d value too long (%lu > %zu bytes max)\n",
+                            __func__, format, anip->id, attr_no,
+                            l, sizeof(avp->value));
+                    return SG_LIB_LBA_OUT_OF_RANGE;
+                }
+                memcpy(avp->value, attr_value, l);
+                avp->val_len = l;
+                break;
+            default:
+                assert(false);
+        }
+    }
+    /* see SCP-5 clause 4.3.1 ASCII data field requirements */
+    if (RA_FMT_ASCII == anip->format && !sg_all_printable(avp->value, avp->val_len)) {
+        pr2serr("%s: ASCII attribute id 0x%04x in attribute-value pair #%d contains non-printable or non-ASCII characters\n", __func__, anip->id, attr_no);
+        return SG_LIB_SYNTAX_ERROR;
+    }
+    if ((RA_FMT_ASCII == anip->format || RA_FMT_TEXT == anip->format) && -1 != avp->len && avp->val_len < avp->len) {
+        memset(&avp->value[avp->val_len], RA_FMT_ASCII == anip->format ? ' ' : '\0', avp->len - avp->val_len);
+        avp->val_len = avp->len;
+    }
+    if (-1 != avp->len) {
+        if (RA_FMT_BINARY == anip->format) {
+            if (avp->val_len != avp->len) {
+                pr2serr("%s: %s attribute id 0x%04x in attribute-value pair #%d value length (%d) does not match attribute length (%d)\n",
+                        __func__, format, anip->id, attr_no,
+                        avp->val_len, avp->len);
+                return SG_LIB_LBA_OUT_OF_RANGE;
+            }
+
+        } else {
+            if (avp->val_len > avp->len) {
+                pr2serr("%s: %s attribute id 0x%04x in attribute-value pair #%d value length (%d) exceeds attribute length (%d)\n",
+                        __func__, format, anip->id, attr_no,
+                        avp->val_len, avp->len);
+                return SG_LIB_LBA_OUT_OF_RANGE;
+            }
+        }
+    }
+    return 0;
+}
+
+/* Parse attribute-value pair delimited by an equal sign '=' or a colon ':'.
+ * Attribute can be either acronym or numerical id in hexadecimal form.
+ * Value is a text string for text or ASCII format attributes,
+ * or comma- or space-delimited hexadecimal string for binary attributes
+ * or with colon attribute-value delimiter.
+ * Unicode text strings are supported only in the UTF-8 character set.
+ * It's recommended to set Text Localization Identifier attribute
+ * when text values contains characters beyond ASCII.
+ * Text and ASCII format values will be left-aligned padded by blanks (ASCII)
+ * or nulls (Text) to their designated length.
+ * Value length for binary attributes must match attribute length exactly,
+ * unless attribute has variable length.
+ * Empty value ("attribute=" or "attribute:") deletes attribute.
+ * Fills in avp structure. Returns 0 on success and 1 on errors.
+ */
+static int
+parse_attribute(char * const inp, const int attr_no, struct attr_value_pair_t * avp)
+{
+    char *attr_name, *attr_value, *dc;
+    const struct attr_name_info_t * anip;
+    bool do_hex;
+
+    /* delimiters: = is for ascii/text string or numerical value, : is for hex sequence */
+    dc = strpbrk(inp, "=:");
+    if (NULL == dc) {
+        pr2serr("%s: attribute-value pair #%d must be separated by '=' or ':' sign\n", __func__, attr_no);
+        return SG_LIB_SYNTAX_ERROR;
+    }
+    do_hex = ':' == *dc;
+    *dc++ = '\0';
+    attr_name = inp;
+    attr_value = dc;
+
+    if (0 == strlen(attr_name)) {
+        pr2serr("%s: no attribute id or acronym in attribute-value pair #%d\n", __func__, attr_no);
+        return SG_LIB_SYNTAX_ERROR;
+    }
+
+    anip = find_attr_by_id(attr_name);
+    if (NULL == anip)
+        anip = find_attr_by_acronym(attr_name);
+    if (NULL == anip) {
+        pr2serr("%s: unknown attribute id or acronym '%s' in attribute-value pair #%d\n", __func__, attr_name, attr_no);
+        return SG_LIB_SYNTAX_ERROR;
+    }
+
+    avp->id = anip->id;
+    avp->name = anip->name;
+    avp->format = anip->format;
+    avp->len = anip->len;
+
+    /* zero-length value deletes the attribute */
+    if (0 == strlen(attr_value)) {
+        avp->val_len = 0;
+        return 0;
+    }
+
+    return parse_attr_value(attr_value, do_hex, attr_no, avp, anip);
+}
+
+/* pack attribute list */
+static int
+pack_attribute_list(const struct attr_value_pair_t * avps, const int avpc, uint8_t * buf, int * buf_len, const int max_buf_len)
+{
+    uint32_t remained_size = max_buf_len;
+    uint32_t item_len;
+    uint8_t * ptr;
+    int i;
+
+    if (remained_size < ATTR_LIST_HEADER_LEN) {
+        pr2serr("%s: attribute list buffer size (%d bytes) is too small to store attribute list header of %d bytes\n",
+                __func__, remained_size, ATTR_LIST_HEADER_LEN);
+        return SG_LIB_LBA_OUT_OF_RANGE;
+    }
+    remained_size -= ATTR_LIST_HEADER_LEN;
+    ptr = buf + ATTR_LIST_HEADER_LEN;
+    for (i = 0, *buf_len = 0; i < avpc; i++, avps++, ptr += item_len, *buf_len += item_len, remained_size -= item_len) {
+        item_len = avps->val_len + ATTR_LIST_ITEM_HEADER_LEN;
+        if (remained_size < item_len) {
+            pr2serr("%s: attribute list remained buffer size (%d of %d bytes) is too small to store attribute #%d 0x%04x (%s) of %d bytes\n",
+                    __func__, remained_size, max_buf_len, i+1, avps->id, avps->name, item_len);
+            return SG_LIB_LBA_OUT_OF_RANGE;
+        }
+        sg_put_unaligned_be16(avps->id, ptr);
+        ptr[2] = avps->format;
+        sg_put_unaligned_be16(avps->val_len, ptr+3);
+        memcpy(ptr+5, avps->value, avps->val_len);
+    }
+    sg_put_unaligned_be32(*buf_len, buf);
+    *buf_len += ATTR_LIST_HEADER_LEN;
+    return 0;
+}
+
+/* Find duplicate attributes in the sorted array */
+static int
+find_duplicates(const struct attr_value_pair_t * avps, const int avpc)
+{
+    int last_dup_id = -1;
+
+    for (int i = 1; i < avpc; i++) {
+        if (avps[i].id == avps[i-1].id && avps[i].id != last_dup_id){
+            pr2serr("Duplicate attribute #%d: 0x%04x (%s)\n", i, avps[i].id, avps[i].name);
+            last_dup_id = avps[i].id;
+        }
+    }
+    return last_dup_id != -1 ? SG_LIB_SYNTAX_ERROR : 0;
+}
+
+static int
+compare_attributes(const struct attr_value_pair_t * a, const struct attr_value_pair_t * b)
+{
+    return a->id - b->id;
+}
+
+/* sort attributes by id in ascending order, find duplicates, pack attribute list */
+static int
+post_process_attributes(struct attr_value_pair_t * avps, const int avps_num, uint8_t * wabp, int * buf_len, const int maxlen)
+{
+    int r;
+
+    /* sort by attribute id in ascending order */
+    qsort(avps, avps_num, sizeof(struct attr_value_pair_t), (int (*)(const void *, const void *)) compare_attributes);
+    /* find duplicates */
+    r = find_duplicates(avps, avps_num);
+    if (!r)
+        r = pack_attribute_list(avps, avps_num, wabp, buf_len, maxlen);
+    return r;
+}
+
+static int
+parse_attributes(char *argv[], const int argc, uint8_t * wabp, int * buf_len, const int maxlen)
+{
+    struct attr_value_pair_t * avps;
+    int r;
+
+    avps = calloc(argc, sizeof(struct attr_value_pair_t));
+    if (NULL == avps) {
+        pr2serr("%s: out of memory allocating %lu bytes\n", __func__, argc * sizeof(struct attr_value_pair_t));
+        return sg_convert_errno(ENOMEM);
+    }
+    /* parse attribute-value pairs */
+    for (int i = 0; i < argc; i++) {
+        r = parse_attribute(argv[i], i + 1, &avps[i]);
+        if (r)
+            goto cleanup;
+    }
+    r = post_process_attributes(avps, argc, wabp, buf_len, maxlen);
+cleanup:
+    free (avps);
+    return r;
+}
+
+/* Read attribute-value pairs from input file line by line */
+static int
+parse_attributes_from_file(const char * fname, const struct opts_t * op, uint8_t * mp_arr, int * mp_arr_len, const int maxlen)
+{
+    bool has_stdin;
+    int fn_len, err;
+    int ret = 0;
+    char * lcp, * end;
+    FILE * fp;
+    char line[512];
+    const char whitespace[] = " \f\n\r\t\v";
+    struct attr_value_pair_t * avps = NULL;
+    int avps_num = 0;
+
+    if ((NULL == fname) || (NULL == op) || (NULL == mp_arr) || (NULL == mp_arr_len)) {
+        pr2ws("%s: bad arguments\n", __func__);
+        return SG_LIB_LOGIC_ERROR;
+    }
+    fn_len = strlen(fname);
+    if (0 == fn_len)
+        return SG_LIB_SYNTAX_ERROR;
+    has_stdin = ((1 == fn_len) && ('-' == fname[0]));   /* read from stdin */
+
+    /* So read the file as ASCII one attribute-value pair per line */
+    if (has_stdin)
+        fp = stdin;
+    else {
+        fp = fopen(fname, "r");
+        if (NULL == fp) {
+            err = errno;
+            pr2ws("Unable to open %s for reading: %s\n", fname,
+                  safe_strerror(err));
+            ret = sg_convert_errno(err);
+            goto fini;
+        }
+    }
+
+    for (;;) {
+        if (NULL == fgets(line, sizeof(line), fp))
+            break;
+
+        /* Trim leading and  trailing space and newline */
+        lcp = line + strspn(line, whitespace);
+        end = lcp + strlen(lcp) - 1;
+        while(end > lcp && isspace(*end)) end--;
+        end[1] = '\0';
+        if ('\0' == *lcp || '#' == *lcp)
+            continue;
+
+        avps = realloc(avps, (avps_num+1) * sizeof(struct attr_value_pair_t));
+        if (NULL == avps) {
+            pr2serr("%s: out of memory allocating %zu bytes\n", __func__, (avps_num+1) * sizeof(struct attr_value_pair_t));
+            ret = sg_convert_errno(ENOMEM);
+            goto fini;
+        }
+        ret = parse_attribute(lcp, avps_num+1, &avps[avps_num]);
+        if (ret)
+            goto fini;
+        avps_num++;
+    }
+    ret = post_process_attributes(avps, avps_num, mp_arr, mp_arr_len, maxlen);
+fini:
+    if (fp && (stdin != fp))
+        fclose(fp);
+    if (avps)
+        free(avps);
+    return ret;
+}
+
+int
+main(int argc, char * argv[])
+{
+    int sg_fd, res, c;
+    int in_len = 0;
+    int ret = 0;
+    int avps_num = 0;
+    const int maxlen = MAX_ATTR_BUFF_LEN;
+    const char * device_name = NULL;
+    const char * fname = NULL;
+    char ** avps = NULL;
+    uint8_t * wabp = NULL;
+    uint8_t * free_wabp = NULL;
+    struct opts_t opts;
+    struct opts_t * op;
+    char b[80];
+
+    op = &opts;
+    memset(op, 0, sizeof(opts));
+    while (1) {
+        int option_index = 0;
+
+        c = getopt_long(argc, argv, "ceE:hHi:l:p:qrt:vV",
+                        long_options, &option_index);
+        if (c == -1)
+            break;
+
+        switch (c) {
+        case 'c':
+            op->wtc = true;
+            break;
+        case 'e':
+            op->enumerate = true;
+            break;
+        case 'E':
+           op->elem_addr = sg_get_num(optarg);
+           if ((op->elem_addr < 0) || (op->elem_addr > 65535)) {
+                pr2serr("bad argument to '--element=EA', expect 0 to 65535\n");
+                return SG_LIB_SYNTAX_ERROR;
+            }
+            break;
+        case 'h':
+        case '?':
+            usage();
+            return 0;
+        case 'H':
+            op->do_hex = true;
+            break;
+        case 'i':
+            fname = optarg;
+            break;
+        case 'l':
+           op->lvn = sg_get_num(optarg);
+           if ((op->lvn < 0) || (op->lvn > 255)) {
+                pr2serr("bad argument to '--lvn=LVN', expect 0 to 255\n");
+                return SG_LIB_SYNTAX_ERROR;
+            }
+            break;
+        case 'p':
+           op->pn = sg_get_num(optarg);
+           if ((op->pn < 0) || (op->pn > 255)) {
+                pr2serr("bad argument to '--pn=PN', expect 0 to 255\n");
+                return SG_LIB_SYNTAX_ERROR;
+            }
+            break;
+        case 'r':
+            op->do_raw = true;
+            break;
+        case 'v':
+            op->verbose_given = true;
+            ++op->verbose;
+            break;
+        case 'V':
+            op->version_given = true;
+            break;
+        default:
+            pr2serr("unrecognised option code 0x%x ??\n", c);
+            usage();
+            return SG_LIB_SYNTAX_ERROR;
+        }
+    }
+    if (optind < argc && NULL == device_name) {
+        device_name = argv[optind];
+        ++optind;
+    }
+    if (optind < argc) {
+        avps = &argv[optind];
+        avps_num = argc - optind;
+    }
+
+#ifdef DEBUG
+    pr2serr("In DEBUG mode, ");
+    if (op->verbose_given && op->version_given) {
+        pr2serr("but override: '-vV' given, zero verbose and continue\n");
+        op->verbose_given = false;
+        op->version_given = false;
+        op->verbose = 0;
+    } else if (! op->verbose_given) {
+        pr2serr("set '-vv'\n");
+        op->verbose = 2;
+    } else
+        pr2serr("keep verbose=%d\n", op->verbose);
+#else
+    if (op->verbose_given && op->version_given)
+        pr2serr("Not in DEBUG mode, so '-vV' has no special action\n");
+#endif
+    if (op->version_given) {
+        pr2serr("version: %s\n", version_str);
+        return 0;
+    }
+
+    if (op->enumerate) {
+        enum_attributes();
+        return 0;
+    }
+
+    if (NULL == device_name) {
+        pr2serr("missing device name!\n");
+        usage();
+        return SG_LIB_SYNTAX_ERROR;
+    }
+
+    wabp = (uint8_t *)sg_memalign(maxlen, 0, &free_wabp, op->verbose > 3);
+    if (NULL == wabp) {
+        pr2serr("unable to sg_memalign %d bytes\n", maxlen);
+        return sg_convert_errno(ENOMEM);
+    }
+
+    if (fname) {
+        if (avps) {
+            pr2serr("since '--in=FN' given, ignoring attribute-value pairs arguments\n");
+            avps = NULL;
+        }
+        if (op->do_raw || op->do_hex) {
+            if (op->do_raw && op->do_hex)
+                pr2serr("both '--raw' and '--hex' given, assuming binary (raw) format\n");
+            if ((ret = sg_f2hex_arr(fname, op->do_raw, false /* no space */,
+                                    wabp, &in_len, maxlen)))
+                goto fini;
+            if (in_len < 4) {
+                pr2serr("--in=%s only decoded %d bytes (needs 4 at least)\n",
+                        fname, in_len);
+                ret = SG_LIB_SYNTAX_ERROR;
+            }
+        } else
+            ret = parse_attributes_from_file(fname, op, wabp, &in_len, maxlen);
+    } else {
+        if (NULL == avps) {
+            pr2serr("missing attribute-value pairs!\n");
+            usage();
+            ret = SG_LIB_SYNTAX_ERROR;
+        } else
+            ret = parse_attributes(avps, avps_num, wabp, &in_len, maxlen);
+    }
+    if (0 != ret)
+        goto fini;
+
+    sg_fd = sg_cmds_open_device(device_name, false /* read-write */, op->verbose);
+    if (sg_fd < 0) {
+        pr2serr("open error: %s: %s\n", device_name,
+                safe_strerror(-sg_fd));
+        ret = sg_convert_errno(-sg_fd);
+        goto clean_up;
+    }
+    res = sg_ll_write_attr(sg_fd, wabp, in_len, op->verbose > 0, op);
+    ret = res;
+    if (0 != res) {
+        if (SG_LIB_CAT_INVALID_OP == res)
+            pr2serr("Write attribute command not supported\n");
+        else {
+            sg_get_category_sense_str(res, sizeof(b), b, op->verbose);
+            pr2serr("Write attribute command: %s\n", b);
+        }
+    }
+
+    res = sg_cmds_close_device(sg_fd);
+    if (res < 0) {
+        pr2serr("close error: %s\n", safe_strerror(-res));
+        if (0 == ret)
+            ret = sg_convert_errno(-res);
+    }
+clean_up:
+    if (0 == op->verbose) {
+        if (! sg_if_can2stderr("sg_write_attr failed: ", ret))
+            pr2serr("Some error occurred, try again with '-v' or '-vv' for "
+                    "more information\n");
+    }
+fini:
+    if (free_wabp)
+        free(free_wabp);
+    return (ret >= 0) ? ret : SG_LIB_CAT_OTHER;
+}


### PR DESCRIPTION
Implemented sg_write_attr utility to set (writable) attributes in the SCSI device using SCSI WRITE ATTRIBUTE command.