### PR TITLE
sg3_utils: Fix issue with rescan-scsi-bus.sh removing hard disks

### DIFF
--- a/scripts/rescan-scsi-bus.sh
+++ b/scripts/rescan-scsi-bus.sh
@@ -306,8 +306,8 @@ testonline ()
   IPROD=$(echo "$INQ" | grep 'Product identification:' | sed 's/^[^:]*: \(.*\)$/\1/')
   IPREV=$(echo "$INQ" | grep 'Product revision level:' | sed 's/^[^:]*: \(.*\)$/\1/')
   STR=$(printf "  Vendor: %-08s Model: %-16s Rev: %-4s" "$IVEND" "$IPROD" "$IPREV")
-  IPTYPE=$(echo "$INQ" | sed -n 's/.* Device_type=\([0-9]*\) .*/\1/p')
-  IPQUAL=$(echo "$INQ" | sed -n 's/ *PQual=\([0-9]*\)  Device.*/\1/p')
+  IPTYPE=$(echo "$INQ" | sed -n 's/.* PDT=\([0-9]*\) .*/\1/p')
+  IPQUAL=$(echo "$INQ" | sed -n 's/ *PQual=\([0-9]*\)  PDT*/\1/p')
   if [ "$IPQUAL" != 0 ] ; then
     [ -z "$IPQUAL" ] && IPQUAL=3
     [ -z "$IPTYPE" ] && IPTYPE=31


### PR DESCRIPTION
sg_inq command, which is part of the sg3_utils package, has been modified to output the string "PDT" instead of "Device_type" in commit d1c58f173918f22723a79d0ab06bcfb60092e75a.
However, rescan-scsi-bus.sh is consuming the output from sq_inq, which has not been updated to use the modified output of sg_inq. As a result, running rescan-scsi-bus.sh with the "-r" option is causing hard disks to be removed. This commit updates rescan-scsi-bus.sh to use the modified output of sg_inq to avoid this issue.